### PR TITLE
fix: improvements in cli experience and localize command

### DIFF
--- a/docs/api/introduction.md
+++ b/docs/api/introduction.md
@@ -1,0 +1,14 @@
+# Octopi 🐙🐙🐙 API
+
+## Introduction
+
+Octopi is a powerful framework for **3D CNN instance segmentation of proteins in Cryo-ET tomograms**. Built on top of MONAI and PyTorch, octopi provides a complete pipeline for training deep learning models to identify and segment macromolecular structures in cryo-electron tomography data.
+
+### Key Features
+
+- **🔧 Flexible Configuration**: Modular design supporting various model architectures and training strategies  
+- **📊 Comprehensive Metrics**: Built-in evaluation with confusion matrices, F1 scores, precision, and recall
+- **⚡ Memory Efficient**: Smart data loading for large tomogram datasets that don't fit in memory
+- **🎯 Specialized Loss Functions**: Weighted Focal Tversky Loss optimized for class-imbalanced volumetric data
+- **🔍 Hyperparameter Optimization**: Integrated Optuna support for automated model exploration
+- **📈 Experiment Tracking**: MLflow integration for reproducible research

--- a/docs/getting-started/data-import.md
+++ b/docs/getting-started/data-import.md
@@ -48,7 +48,7 @@ The copick configuration file points to a directory that stores all the tomogram
 ```
 </details>
 
-## Importing Local MRC Files
+## Importing Local MRC Tomograms
 
 If you have tomograms stored locally in `*.mrc` format (e.g., from Warp, IMOD, or AreTomo), you can import them into a copick project:
 
@@ -73,9 +73,9 @@ To satisfy the recommended resolution requirement, we can downsample tomograms t
 | `--input-voxel-size` | Voxel size of your input MRC files (in Ångströms) | `5` (for 5Å data) |
 | `--output-voxel-size` | (Optional) Target voxel size after downsampling | `10` (downsample to 10Å) |
 
-## Working with CryoET Data Portal
+## Downloading from the CryoET Data-Portal
 
-The CryoET Data Portal provides access to thousands of annotated tomograms. Octopi can work with this data in two ways:
+The [CryoET Data Portal](https://cryoetdataportal.czscience.com) provides access to thousands of annotated tomograms. Octopi can work with this data in two ways:
 
 ### 1. Direct Portal Access
 

--- a/docs/user-guide/advanced-training.md
+++ b/docs/user-guide/advanced-training.md
@@ -2,7 +2,51 @@
 
 This guide covers everything you need to know about training 3D U-Net models with Octopi. Here, we are fixing the model architecture. For those interested in writing their own training functions, refer to the API. 
 
+## Single Model Training
 
-## Training Single Models
+For specific use cases or when you have a known good architecture, you can train a single model directly. In this case, the command only allows for training U-Net models. To play around with more unique model configurations, or to try importing new model designs refer to the API or `octopi model-explore`. 
+
+### Basic Training Command
+
+```bash
+octopi train \
+    --config config.json \
+    --voxel-size 10 --tomo-alg wbp --Nclass 8 \
+    --tomo-batch-size 50 --num-epochs 100 --val-interval 10 \
+    --target-info targets,octopi,1
+```
 
 ## Fine Tuning Models
+
+If we have base weights that we would like to fine-tune for new datasets, we can still use the `train` command. Instead of specifying the model architecture, we can simple point to the configuration file and weights to load the existing model to fine tune.
+
+```bash
+octopi train \
+    --config config.json \
+    --voxel-size 10 --tomo-alg wbp \
+    --model-config results/model_config.yaml \
+    --model-weights results/best_model_weights.pth
+```
+
+#### Training Outputs
+
+Training Output
+During training, you'll see:
+
+* Progress indicators: Real-time loss and accuracy metrics
+* Validation results: Periodic evaluation on validation set
+* Model checkpoints: Saved to results/ directory by default
+* Training logs: Detailed logs for monitoring and debugging
+
+### Training Parameters
+
+| Parameter | Description | Example Value |
+|-----------|-------------|---------------|
+| `--config` | Path to copick configuration file  | `config.json` |
+| `--voxel-size` | Tomogram voxel size (Angstroms) | `10` |
+| `--tomo-alg` | Tomographic reconstruction algorithm | `wbp` (weighted back projection) |
+| `--Nclass` | Number of output classes for segmentation | `8` |
+| `--tomo-batch-size` | Batch size for tomographic processing | `50` |
+| `--num-epochs` | Total number of training epochs | `100` |
+| `--val-interval` | Validation frequency (every N epochs) | `10` |
+| `--target-info` | Target information in format: name,framework,version | `targets,octopi,1` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,9 @@ nav:
     - Model Exploration: user-guide/training-basics.md
     - Advanced Training: user-guide/advanced-training.md
     - Inference: user-guide/inference.md
-  - API Tutorial: user-guide/api-tutorial.md
+  - API Tutorial: 
+    - Overview: api/introduction.md
+    - Quick Start: api/quick-start.md
 
 extra:
   social:

--- a/octopi/entry_points/run_localize.py
+++ b/octopi/entry_points/run_localize.py
@@ -5,6 +5,7 @@ import copick, argparse, pprint
 from typing import List, Tuple
 import multiprocess as mp
 from tqdm import tqdm
+import os
 
 def pick_particles(
     copick_config_path: str,
@@ -40,56 +41,40 @@ def pick_particles(
     print(', '.join([f'{obj[0]} (Label: {obj[1]})' for obj in objects]) + '\n')
 
     # Either Specify Input RunIDs or Run on All RunIDs
-    if runIDs:  print('Running Localization on the Following RunIDs: ' + ', '.join(runIDs) + '\n')
-    run_ids = runIDs if runIDs else [run.name for run in root.runs]
+    if runIDs:
+        print('Running Localization on the Following RunIDs: ' + ', '.join(runIDs) + '\n')
+        run_ids = runIDs
+    else:
+        run_ids = [run.name for run in root.runs if run.get_voxel_spacing(voxel_size) is not None]
+        skipped_run_ids = [run.name for run in root.runs if run.get_voxel_spacing(voxel_size) is None]
+
+        if skipped_run_ids:
+            print(f"Warning: skipping runs with no voxel spacing {voxel_size}: {skipped_run_ids}")
+
     n_run_ids = len(run_ids)
 
     # Determine the number of processes to use
     if n_procs is None:
-        n_procs = min(int(mp.cpu_count()//4), n_run_ids)
+        n_procs = min(n_run_ids, int(os.environ.get('SLURM_CPUS_PER_TASK', mp.cpu_count())))
     print(f"Using {n_procs} processes to parallelize across {n_run_ids} run IDs.")
 
-    # Initialize tqdm progress bar
-    with tqdm(total=n_run_ids, desc="Localization", unit="run") as pbar:
-        for _iz in range(0, n_run_ids, n_procs):
+    with mp.Pool(processes=n_procs) as pool:
+        with tqdm(total=n_run_ids, desc="Localization", unit="run") as pbar:
+            worker_func = lambda run_id: localize.processs_localization(
+                root.get_run(run_id),  
+                objects, 
+                seg_info,
+                method, 
+                voxel_size,
+                filter_size,
+                radius_min_scale, 
+                radius_max_scale,
+                pick_session_id,
+                pick_user_id
+            )
 
-            start_idx = _iz
-            end_idx = min(_iz + n_procs, n_run_ids)  # Ensure end_idx does not exceed n_run_ids
-            print(f"\nProcessing runIDs from {start_idx} -> {end_idx } (out of {n_run_ids})")
-
-            processes = []                
-            for _in in range(n_procs):
-                _iz_this = _iz + _in
-                if _iz_this >= n_run_ids:
-                    break
-                run_id = run_ids[_iz_this]
-                run = root.get_run(run_id)
-                p = mp.Process(
-                    target=localize.processs_localization,
-                    args=(run,  
-                          objects, 
-                          seg_info,
-                          method, 
-                          voxel_size,
-                          filter_size,
-                          radius_min_scale, 
-                          radius_max_scale,
-                          pick_session_id,
-                          pick_user_id),
-                )
-                processes.append(p)
-
-            for p in processes:
-                p.start()
-
-            for p in processes:
-                p.join()
-
-            for p in processes:
-                p.close()
-
-            # Update tqdm progress bar
-            pbar.update(len(processes))
+            for _ in pool.imap_unordered(worker_func, run_ids, chunksize=1):
+                pbar.update(1)
 
     print('Localization Complete!')
 

--- a/octopi/processing/create_targets_from_picks.py
+++ b/octopi/processing/create_targets_from_picks.py
@@ -42,7 +42,11 @@ def generate_targets(
 
     # If runIDs are not provided, load all runs
     if run_ids is None:
-        run_ids = [run.name for run in root.runs]
+        run_ids = [run.name for run in root.runs if run.get_voxel_spacing(voxel_size) is not None]
+        skipped_run_ids = [run.name for run in root.runs if run.get_voxel_spacing(voxel_size) is None]
+        
+        if skipped_run_ids:
+            print(f"Warning: skipping runs with no voxel spacing {voxel_size}: {skipped_run_ids}")
 
     # Iterate Over All Runs
     for runID in tqdm(run_ids):

--- a/octopi/processing/downsample.py
+++ b/octopi/processing/downsample.py
@@ -102,11 +102,6 @@ class FourierRescale:
         """
         in_depth, in_height, in_width = volume.shape[-3:]
         
-        # Check if dimensions are odd
-        d_is_odd = in_depth % 2
-        h_is_odd = in_height % 2
-        w_is_odd = in_width % 2
-        
         # Calculate new dimensions
         extent_depth = in_depth * self.input_voxel_size[0]
         extent_height = in_height * self.input_voxel_size[1]
@@ -121,9 +116,10 @@ class FourierRescale:
         new_height = new_height - (new_height % 2)
         new_width = new_width - (new_width % 2)
         
-        # Calculate starting points with odd/even correction
-        start_d = (in_depth - new_depth) // 2 + (d_is_odd)
-        start_h = (in_height - new_height) // 2 + (h_is_odd)
-        start_w = (in_width - new_width) // 2 + (w_is_odd)
+        # Calculate starting points - properly centered around DC component
+        # No odd/even correction needed - just center the crop
+        start_d = (in_depth - new_depth) // 2
+        start_h = (in_height - new_height) // 2
+        start_w = (in_width - new_width) // 2
         
         return start_d, start_h, start_w, new_depth, new_height, new_width

--- a/octopi/pytorch/model_search_submitter.py
+++ b/octopi/pytorch/model_search_submitter.py
@@ -16,16 +16,16 @@ class ModelSearchSubmit:
         voxel_size: float,
         Nclass: int,
         model_type: str,
-        mlflow_experiment_name: str,
-        random_seed: int,
-        num_epochs: int,
-        num_trials: int,
-        tomo_batch_size: int,
-        best_metric: str,
-        val_interval: int,
-        trainRunIDs: List[str],
-        validateRunIDs: List[str],
-        data_split: str
+        best_metric: str = 'avg_f1',
+        num_epochs: int = 1000,
+        num_trials: int = 100,
+        data_split: str = 0.8,
+        random_seed: int = 42,
+        val_interval: int = 10,
+        tomo_batch_size: int = 15,
+        trainRunIDs: List[str] = None,
+        validateRunIDs: List[str] = None,
+        mlflow_experiment_name: str = 'explore',
     ):
         """
         Initialize the ModelSearch class for architecture search with Optuna.
@@ -207,7 +207,7 @@ class ModelSearchSubmit:
             # Run multi-GPU optimization
             study = self.get_optuna_study()
             study.optimize(
-                lambda trial: BayesianModelSearch(self.data_generator, self.model_type).multi_gpu_objective(
+                lambda trial: hyper_search.BayesianModelSearch(self.data_generator, self.model_type).multi_gpu_objective(
                     parent_run, trial,
                     self.num_epochs,
                     best_metric=self.best_metric,

--- a/octopi/pytorch/segmentation.py
+++ b/octopi/pytorch/segmentation.py
@@ -193,8 +193,12 @@ class Predictor:
         
         # If runIDs are not provided, load all runs
         if runIDs is None:
-            runIDs = [run.name for run in self.root.runs]
-        
+            runIDs = [run.name for run in self.root.runs if run.get_voxel_spacing(voxel_spacing) is not None]
+            skippedRunIDs = [run.name for run in self.root.runs if run.get_voxel_spacing(voxel_spacing) is None]
+
+            if skippedRunIDs:
+                print(f"Warning: skipping runs with no voxel spacing {voxel_spacing}: {skippedRunIDs}")
+
         # Iterate over batches of runIDs
         for i in range(0, len(runIDs), num_tomos_per_batch):
 


### PR DESCRIPTION
- better handling of mismatched voxel spacing & run ids for create-targets, segment, and localize
    - if a voxel spacing doesn't exist in a run id, the user is warned and the command will just skip that run instead of crash
- the localize command now uses the minimum from the number of runs and the number cpus the os has (or cpus assigned per task it if slurm)