### PR TITLE
fix: Adapt mednext builder to match unet builder patterns

### DIFF
--- a/octopi/datasets/augment.py
+++ b/octopi/datasets/augment.py
@@ -12,6 +12,7 @@ from monai.transforms import (
     RandGaussianNoised,
     ScaleIntensityRanged,  
     RandomOrder,
+    RandSpatialCropd
 )
 
 def get_transforms():
@@ -38,12 +39,18 @@ def get_random_transforms( input_dim, num_samples, Nclasses):
     the first axis (spatial_axes=[1, 2]) and avoid flipping along the first axis.
     """
     return Compose([
-        RandCropByLabelClassesd(
+        # RandCropByLabelClassesd(
+        #     keys=["image", "label"],
+        #     label_key="label",
+        #     spatial_size=[input_dim[0], input_dim[1], input_dim[2]],
+        #     num_classes=Nclasses,
+        #     num_samples=num_samples
+        # ),
+        RandSpatialCropd(
             keys=["image", "label"],
-            label_key="label",
-            spatial_size=[input_dim[0], input_dim[1], input_dim[2]],     
-            num_classes=Nclasses,
-            num_samples=num_samples
+            roi_size=[input_dim[0], input_dim[1], input_dim[2]],
+            random_center=True,
+            random_size=False
         ),
         # Only rotate around the first axis (keeping the missing wedge orientation consistent)
         RandRotate90d(keys=["image", "label"], prob=0.5, spatial_axes=[1, 2], max_k=3),

--- a/octopi/models/MedNeXt.py
+++ b/octopi/models/MedNeXt.py
@@ -27,7 +27,7 @@ class myMedNeXt:
             decoder_expansion_ratio=self.config["decoder_expansion_ratio"],
             bottleneck_expansion_ratio=self.config["bottleneck_expansion_ratio"],
             kernel_size=self.config["kernel_size"],
-            deep_supervision=self.config["deep_supervision"],
+            deep_supervision=False,
             norm_type=self.config["norm_type"],
             global_resp_norm=self.config["global_resp_norm"],
             blocks_down=self.config["blocks_down"],
@@ -50,8 +50,8 @@ class myMedNeXt:
         decoder_expansion_ratio = trial.suggest_int("decoder_expansion_ratio", 1, 3)
         bottleneck_expansion_ratio = trial.suggest_int("bottleneck_expansion_ratio", 1, 4)
         kernel_size = trial.suggest_categorical("kernel_size", [3, 5])
-        deep_supervision = trial.suggest_categorical("deep_supervision", [True, False])
-        norm_type = trial.suggest_categorical("norm_type", ["group", "instance"])
+        deep_supervision = trial.suggest_categorical("deep_supervision", [False])
+        norm_type = trial.suggest_categorical("norm_type", ["group"])  #"layer" causes crash
         # For extremely low SNR, you might opt to disable global response normalization
         global_resp_norm = trial.suggest_categorical("global_resp_norm", [True, False])
         

--- a/octopi/models/MedNeXt.py
+++ b/octopi/models/MedNeXt.py
@@ -10,42 +10,33 @@ class myMedNeXt:
 
     def build_model(
         self,
-        init_filters=32,
-        encoder_expansion_ratio=2,
-        decoder_expansion_ratio=2,
-        bottleneck_expansion_ratio=2,
-        kernel_size=7,
-        deep_supervision=False,
-        use_residual_connection=False,
-        norm_type="group",
-        global_resp_norm=False,
-        blocks_down=(2, 2, 2, 2),
-        blocks_bottleneck=2,
-        blocks_up=(2, 2, 2, 2),
+        config,
     ):
         """
         Create the MedNeXt model with the specified hyperparameters.
         Note: For cryoET with small objects, a shallower network might help preserve details.
         """
+        self.config = config
         self.model = MedNeXt(
             spatial_dims=3,
             in_channels=1,
-            out_channels=self.num_classes,
-            init_filters=init_filters,
-            encoder_expansion_ratio=encoder_expansion_ratio,
-            decoder_expansion_ratio=decoder_expansion_ratio,
-            bottleneck_expansion_ratio=bottleneck_expansion_ratio,
-            kernel_size=kernel_size,
-            deep_supervision=deep_supervision,
-            use_residual_connection=use_residual_connection,
-            norm_type=norm_type,
-            global_resp_norm=global_resp_norm,
-            blocks_down=blocks_down,
-            blocks_bottleneck=blocks_bottleneck,
-            blocks_up=blocks_up,
-        ).to(self.device)
+            use_residual_connection=True,
+            out_channels=self.config["num_classes"],
+            init_filters=self.config["init_filters"],
+            encoder_expansion_ratio=self.config["encoder_expansion_ratio"],
+            decoder_expansion_ratio=self.config["decoder_expansion_ratio"],
+            bottleneck_expansion_ratio=self.config["bottleneck_expansion_ratio"],
+            kernel_size=self.config["kernel_size"],
+            deep_supervision=self.config["deep_supervision"],
+            norm_type=self.config["norm_type"],
+            global_resp_norm=self.config["global_resp_norm"],
+            blocks_down=self.config["blocks_down"],
+            blocks_bottleneck=self.config["blocks_bottleneck"],
+            blocks_up=self.config["blocks_up"],
+        )
+        return self.model
 
-    def bayesian_search(self, trial):
+    def bayesian_search(self, trial, num_classes):
         """
         Defines the Bayesian optimization search space and builds the model with suggested parameters.
         The search space has been adapted for cryoET applications:
@@ -62,12 +53,12 @@ class myMedNeXt:
         deep_supervision = trial.suggest_categorical("deep_supervision", [True, False])
         norm_type = trial.suggest_categorical("norm_type", ["group", "instance"])
         # For extremely low SNR, you might opt to disable global response normalization
-        global_resp_norm = trial.suggest_categorical("global_resp_norm", [False])
+        global_resp_norm = trial.suggest_categorical("global_resp_norm", [True, False])
         
         # Architecture: shallow vs. deep.
         # For small objects, a shallower network (fewer downsampling stages) may preserve spatial detail.
-        architecture = trial.suggest_categorical("architecture", ["shallow", "deep"])
-        if architecture == "shallow":
+        mednext_architecture = trial.suggest_categorical("architecture", ["shallow", "deep"])
+        if mednext_architecture == "shallow":
             blocks_down = (2, 2, 2)         # 3 downsampling stages
             blocks_bottleneck = 2
             blocks_up = (2, 2, 2)
@@ -76,36 +67,27 @@ class myMedNeXt:
             blocks_bottleneck = 2
             blocks_up = (2, 2, 2, 2)
 
-        self.build_model(
-            init_filters=init_filters,
-            encoder_expansion_ratio=encoder_expansion_ratio,
-            decoder_expansion_ratio=decoder_expansion_ratio,
-            bottleneck_expansion_ratio=bottleneck_expansion_ratio,
-            kernel_size=kernel_size,
-            deep_supervision=deep_supervision,
-            use_residual_connection=True,
-            norm_type=norm_type,
-            global_resp_norm=False,
-            blocks_down=blocks_down,
-            blocks_bottleneck=blocks_bottleneck,
-            blocks_up=blocks_up,
-        )
+        self.config = {
+            "architecture": "MedNeXt",
+            "num_classes": num_classes,
+            "init_filters": init_filters,
+            "encoder_expansion_ratio": encoder_expansion_ratio,
+            "decoder_expansion_ratio": decoder_expansion_ratio,
+            "bottleneck_expansion_ratio": bottleneck_expansion_ratio,
+            "kernel_size": kernel_size,
+            "deep_supervision": deep_supervision,
+            "norm_type": norm_type,
+            "global_resp_norm": global_resp_norm,
+            "blocks_down": blocks_down,
+            "blocks_bottleneck": blocks_bottleneck,
+            "blocks_up": blocks_up,
+        }
+
+        return self.build_model(self.config)
 
     def get_model_parameters(self):
         """Retrieve stored model parameters."""
         if self.model is None:
             raise ValueError("Model has not been initialized yet. Call build_model() or bayesian_search() first.")
         
-        return {
-            'architecture': 'MedNeXt',
-            'num_classes': self.num_classes,
-            'init_filters': self.model.init_filters,
-            'encoder_expansion_ratio': self.model.encoder_expansion_ratio,
-            'decoder_expansion_ratio': self.model.decoder_expansion_ratio,
-            'bottleneck_expansion_ratio': self.model.bottleneck_expansion_ratio,
-            'kernel_size': self.model.kernel_size,
-            'deep_supervision': self.model.do_ds,
-            'use_residual_connection': self.model.use_residual_connection,
-            'norm_type': self.model.norm_type,
-            'global_resp_norm': self.model.global_resp_norm,
-        }
+        return self.config


### PR DESCRIPTION
MedNeXt model builder was using outdated builder pattern. This PR updates `myMedNeXt` to match the API used by `myUNet`. 