### PR TITLE
fix: localize api and save model config at beginning of training

### DIFF
--- a/octopi/extract/localize.py
+++ b/octopi/extract/localize.py
@@ -1,5 +1,6 @@
 from scipy.sparse.csgraph import connected_components
-from skimage.morphology import binary_opening, ball
+# from skimage.morphology import binary_opening, ball
+from skimage.morphology import opening, ball
 from skimage.segmentation import watershed
 from scipy.sparse import coo_matrix
 from scipy.spatial import cKDTree
@@ -46,7 +47,7 @@ def extract_coordinates(
     if label <= 0:
         raise ValueError("Label must be a positive integer corresponding to a segmentation label.")
     elif label > seg.max():
-        raise ValueError(f"Label {label} exceeds maximum label in segmentation ({seg.max()}).")
+        return np.empty((0, 3))  # No such label in segmentation; return empty array
 
     if method not in ['watershed', 'com']:
         raise ValueError(f"Invalid method '{method}'. Expected 'watershed' or 'com'.")
@@ -134,11 +135,12 @@ def process_localization(
             label, method, filter_size,
         )
 
-        # Swap to (X,Y,Z) for CoPick; downstream expects (N,3) in XYZ order
-        points = points[:,[2,1,0]] 
-        points *= voxel_size
-
         if points.size > 2:
+
+            # Swap to (X,Y,Z) for CoPick; downstream expects (N,3) in XYZ order
+            points = points[:,[2,1,0]] 
+            points *= voxel_size
+
             picks = run.new_picks(
                 object_name=name, session_id=pick_session_id,
                 user_id=pick_user_id, exist_ok=True)
@@ -183,7 +185,7 @@ def extract_particle_centroids_via_watershed(
     mask_c = mask[z0:z1, y0:y1, x0:x1]
 
     # --- single-pass morphology (speeds + denoise speckles) ---
-    opened = binary_opening(mask_c, ball(1))  # bool in, bool out
+    opened = opening(mask_c, ball(1))  # bool in, bool out
     if not opened.any():
         return []
 

--- a/octopi/utils/io.py
+++ b/octopi/utils/io.py
@@ -121,6 +121,21 @@ def get_optimizer_parameters(trainer):
     return optimizer_parameters
 
 
+def save_init_model_config(model, dataloader, filename):
+    """
+    Save the initial model configuration to a YAML file.
+    """
+
+    # Combine and flatten parameters
+    parameters = {
+        'model': model.get_model_parameters(),
+        'dataloader': dataloader.get_dataloader_parameters()
+    }
+
+    save_parameters_yaml(parameters, filename)
+    print(f"⚙️ Initial Model Configuration saved to {filename}")
+
+
 def save_parameters_to_yaml(model, trainer, dataloader, filename: str):
     """
     Save training parameters to a YAML file.

--- a/octopi/workflows.py
+++ b/octopi/workflows.py
@@ -84,7 +84,9 @@ def train(data_generator, loss_function, batch_size = 16,
     print()
 
     # Train the Model
-    print(f'🔃 Starting Training...\nSaving Training Results to: {model_save_path}/\n')
+    print(f'🔃 Starting Training...\nSaving Results to: {model_save_path}/\n')
+    cfg_name = os.path.join(model_save_path, "model_config.yaml")
+    io.save_init_model_config(model_builder, data_generator, cfg_name)
     results = model_trainer.train(
         data_generator, model_save_path, max_epochs=num_epochs,
         crop_size=model_config['dim_in'], my_num_samples=batch_size,
@@ -93,13 +95,9 @@ def train(data_generator, loss_function, batch_size = 16,
     print('✅ Training Complete!')
 
     # Save parameters and results
-    print(f'💾 Saving Training Parameters and Results to: {model_save_path}/\n')
-    parameters_save_name = os.path.join(model_save_path, "model_config.yaml")
-    io.save_parameters_to_yaml(model_builder, model_trainer, data_generator, parameters_save_name)
-
-    # TODO: Write Results to CSV...
-    results_save_name = os.path.join(model_save_path, "results.csv")
-    io.save_results_to_csv(results, results_save_name)
+    print(f'💾 Saving Training Results...\n')
+    io.save_parameters_to_yaml(model_builder, model_trainer, data_generator, cfg_name)
+    io.save_results_to_csv(results, os.path.join(model_save_path, "results.csv"))
 
 def segment(config, tomo_algorithm, voxel_size, model_weights, model_config, 
             seg_info = ['predict', 'octopi', '1'], run_ids = None, batch_size = 1,


### PR DESCRIPTION
- Fix extract_coordinates label handling: Instead of raising an error when a label isn't found in the segmentation, return an empty array — allowing processing to continue gracefully when a class is absent from a given tomogram.                                                                                              
  - Fix coordinate transform guard: Move the XYZ swap and voxel-size scaling inside the if points.size > 2 check, preventing operations on empty arrays.
  - Replace binary_opening with opening: skimage.morphology.binary_opening was deprecated/removed; switched to opening which handles boolean arrays equivalently.                                                                                                                                                                   
  - Save model config before training starts: model_config.yaml is now written at the beginning of training (not just at the end), so partial runs still produce a config file. After training, save_parameters_to_yaml overwrites it with the full post-training parameters. 