### PR TITLE
fix: Improve training and validation efficiency for large tomography datasets

### DIFF
--- a/docs/user-guide/training.md
+++ b/docs/user-guide/training.md
@@ -81,6 +81,9 @@ Octopi supports two complementary workflows:
             | `--background-ratio` | Foreground/background crop sampling ratio. | `0.0` |
             | `--tversky-alpha` | Alpha parameter for the Tversky loss (foreground weighting). | `0.3` |
 
+            !!! tip "Choosing `--ncache-tomos`"
+                Use this parameter when your dataset has more tomograms than can fit into memory at once — only the cached subset is loaded per epoch, keeping memory usage bounded. Values between **8 and 32** are recommended. Higher values expose the model to more diversity per epoch and improve training throughput, but require more RAM.
+
         === "UNet Architecture"
 
             | Parameter | Description | Default |
@@ -163,9 +166,12 @@ Octopi supports two complementary workflows:
             | `--model-type` | Model family used for exploration. | `Unet` | Options: `unet`, `attentionunet`, `mednext`, `segresnet` |
             | `--num-epochs` | Number of epochs per trial. | `1000` | Consider fewer epochs for quick sweeps |
             | `--val-interval` | Validation frequency (every N epochs). | `10` | Smaller = more frequent metrics |
-            | `--ncache-tomos` | Number of tomograms cached per epoch (SmartCache window size). | `15` | Higher may improve throughput if memory allows |
+            | `--ncache-tomos` | Number of tomograms cached per epoch (SmartCache window size). | `15` | Higher values improve throughput but require more memory |
             | `--best-metric` | Metric used to select the best checkpoint (supports `fBetaN`). | `avg_f1` | Example: `fBeta3` emphasizes recall |
             | `--background-ratio` | Foreground/background crop sampling ratio. | `0.0` | `1.0` → 50/50; `<1.0` biases toward foreground |
+
+            !!! tip "Choosing `--ncache-tomos`"
+                Use this parameter when your dataset has more tomograms than can fit into memory at once — only the cached subset is loaded per epoch, keeping memory usage bounded. Values between **8 and 32** are recommended. Higher values expose the model to more diversity per epoch and improve training throughput, but require more RAM.
 
         === "Search / Reproducibility"
 

--- a/docs/user-guide/training.md
+++ b/docs/user-guide/training.md
@@ -399,6 +399,142 @@ Weights are applied in two places:
 
 ---
 
+## Compute & Performance
+
+This section covers practical recommendations for allocating compute, diagnosing bottlenecks, and recovering from out-of-memory (OOM) errors. If you're just getting started, the defaults work on most hardware — come back here if you need to tune throughput or hit an OOM.
+
+### Requesting resources
+
+Octopi auto-scales at runtime: it reads `os.sched_getaffinity(0)` to match SLURM's `--cpus-per-task`, detects GPU VRAM and compute capability for mixed precision, and picks between `CacheDataset` and `SmartCacheDataset` based on `--ncache-tomos`. The main lever is **what you ask SLURM for**.
+
+=== "HPC / GPU cluster"
+
+    ```bash
+    #SBATCH --cpus-per-task=16
+    #SBATCH --mem-per-cpu=12G
+    #SBATCH --gpus=1
+    #SBATCH --constraint=[h100|h200|a100]
+    ```
+
+    **16 CPUs** saturates the DataLoader worker pool (cap is 16). **12 GB/CPU → 192 GB total** leaves comfortable headroom for worker copy-on-write drift on large caches. Drop to `8G` if your cluster is tight and you cache fewer than ~15 tomograms.
+
+=== "Workstation (24 GB class GPU)"
+
+    Local workstation with RTX 3090/4090, A5000, etc.:
+
+    - **8–12 CPUs** is enough worker throughput for most datasets.
+    - **64–96 GB system RAM** — budget ~1–2 GB per worker plus ~0.5–2 GB per cached tomogram.
+
+=== "Laptop / small GPU"
+
+    Limited to 8–16 GB VRAM, 16–32 GB system RAM:
+
+    - Lower `--ncache-tomos` so the training cache fits in RAM.
+    - Lower `--batch-size` from 16 → 8 to fit the GPU.
+    - Drop `--dim-in` from 96 → 64 for another ~3.4× activation-memory reduction.
+
+### Recommended knobs by GPU tier
+
+| GPU tier | Examples | `--batch-size` | Mixed precision (auto) | System RAM |
+|---|---|---:|---|---|
+| ≤ 12 GB | RTX 4070, 3060 12 GB, T4 | 8 | fp16 + GradScaler | 16–32 GB |
+| 16 GB | RTX A4000, 4060 Ti 16 GB, V100, L4 | 16 | fp16 / bf16 | 32–64 GB |
+| 24 GB | RTX 4090, 3090, A5000 | 16–32 | bf16 | 64–128 GB |
+| 40–48 GB | A100 40 GB, A6000, L40 | 32–48 | bf16 | 128 GB |
+| ≥ 80 GB | A100 80 GB, H100, H200 | 48–64 | bf16 | 128–192 GB |
+
+Octopi selects mixed precision automatically:
+
+- **bf16** on Ampere and newer (RTX 30xx/40xx, A100, H100, H200) — no gradient scaler needed.
+- **fp16 + `GradScaler`** on Volta/Turing (V100, T4, RTX 20xx).
+- **fp32** on Pascal and older, or on CPU.
+
+### Where memory goes
+
+!!! info "System RAM breakdown"
+
+    | Component | Rough cost | Notes |
+    |---|---|---|
+    | Main process (Python + PyTorch + CUDA) | ~3 GB | Fixed |
+    | Cached training tomograms | ~500 MB – 2 GB each | Depends on volume size and dtype |
+    | Cached validation tomograms | ~500 MB – 2 GB each | Usually 2–6 val tomograms |
+    | Each DataLoader training worker | ~1–2 GB overhead | × `num_workers` |
+    | Worker copy-on-write drift | up to cache size per worker | Accumulates during an epoch, resets when the worker dies |
+    | Validation prefetch | ~1–2 GB × `val_workers` × 2 | Only during validation |
+    | Matplotlib training-curve figure | ~0.5–2 GB | Grows slowly across validations |
+
+    Worst-case RAM peak is usually right *after* the first validation, when validation-only allocations are still resident and training workers re-fork for the next epoch. Size the cgroup for this peak.
+
+!!! info "GPU VRAM breakdown (default UNet at 96³)"
+
+    | Component | Rough cost |
+    |---|---|
+    | CUDA context | ~0.5 GB |
+    | Model weights | 0.05–0.2 GB |
+    | Optimizer state (AdamW, fp32) | 2× model weights |
+    | Activations (bf16, batch 16) | ~3–5 GB |
+    | Activations (bf16, batch 32) | ~8–10 GB |
+    | Validation forward (64 patches at 128³) | ~2 GB transient |
+
+### Diagnosing CPU-bound vs GPU-bound
+
+Run `nvidia-smi dmon -s u -d 2 -c 20` in a second terminal during a training epoch (skip the first — `cudnn.benchmark` autotune and cache init make it unrepresentative).
+
+| `sm` utilization | Interpretation | What to try |
+|---|---|---|
+| >85% sustained | **GPU-bound** — GPU is the limit | Larger `--batch-size`; future `torch.compile` or `channels_last_3d` support |
+| 40–70% with regular dips | **Partially data-bound** — workers can't keep GPU fed | More CPUs, higher `--ncache-tomos` |
+| <30% | **Severely data-bound** | More CPUs, bigger cache, or match your CPU/GPU budget better |
+
+!!! tip "Same epoch time on different GPUs?"
+    If training takes the same wall-clock on an A6000 and an H100, you're definitely data-bound — the GPU never gets a chance to differentiate itself. This is a clean diagnostic.
+
+### Troubleshooting OOMs
+
+=== "RAM OOM"
+
+    Symptoms: `Detected N oom_kill events in StepId=...` from `slurmstepd`, or `DataLoader worker (pid N) killed by signal: Killed` after a few epochs.
+
+    In order of preference:
+
+    1. **Bump `--mem-per-cpu`** — e.g., `8G → 12G` on a 16-CPU allocation adds 64 GB. Cheapest fix.
+    2. **Lower `--ncache-tomos`** — each cached tomogram is copy-on-write-shared to every worker; cache size × worker count is the worst-case drift.
+    3. **Lower `val_batch_size`** — the `CopickDataModule.create` default is 64; drop to 32 if validation OOMs.
+    4. **Lower the training-worker cap** — in `octopi/datasets/helpers.py`, adjust `auto_num_workers(cap=...)` from 16 → 12 → 8. Costs ~15% on epoch throughput but significantly reduces peak RAM.
+    5. **Enable glibc trim** in your SLURM script:
+       ```bash
+       export MALLOC_TRIM_THRESHOLD_=0
+       export MALLOC_ARENA_MAX=2
+       ```
+       Forces the C allocator to return freed memory to the OS more aggressively.
+
+=== "GPU OOM"
+
+    Symptoms: `CUDA out of memory. Tried to allocate ...`.
+
+    In order of preference:
+
+    1. **Lower `--batch-size`** (crops per tomogram) — the biggest GPU VRAM lever. Drop 32 → 16 → 8.
+    2. **Lower `--dim-in`** (crop size) — 96 → 64 cuts activation memory ~3.4×.
+    3. **Lower `val_batch_size`** — from 128 → 64 → 32.
+    4. **Disable EMA** (`use_ema=False` in the API) — saves one model-sized shadow copy.
+    5. **Shrink the model** — e.g., `--channels 32,64,80,80` instead of larger variants.
+
+!!! warning "OOMs that first appear around `val_interval`"
+    The first validation adds a persistent ~5–10 GB baseline (MONAI transform caches, matplotlib figure, larger CUDA pool) that is not released. If you survive epochs 0..N and crash shortly after the first validation at epoch `val_interval`, you're pressing against the cgroup limit. Either bump `--mem-per-cpu` or reduce `val_batch_size`.
+
+### Why memory drifts over epochs
+
+A short explanation of what you're fighting when you hit RAM OOMs after running fine for many epochs:
+
+- **Copy-on-write drift.** When PyTorch forks DataLoader workers, each shares the main-process memory via copy-on-write. Reads are "free" — except in Python, even *reading* an object increments a reference count, which writes to memory. So workers slowly accumulate private copies of the cached tomogram pages they touch. Over one epoch each worker can drift by up to the training cache size. Workers dying at the end of each epoch reclaims it (octopi uses `persistent_workers=False` deliberately for this reason).
+- **Python and glibc keep freed memory.** Freed allocations go to allocator pools, not back to the kernel. From the cgroup's perspective, RSS is roughly monotonically non-decreasing until peak usage.
+- **Validation adds a sticky baseline.** First-time validation expands the CUDA caching allocator, imports code paths for the first time, creates a long-lived matplotlib figure, and builds class-index caches. None of this is released.
+
+Together, these mean main-process RAM grows over the first few epochs and then plateaus. If that plateau + per-epoch worker drift ≈ cgroup limit, you OOM. The fix is more RAM, less drift (fewer workers, smaller cache), or less baseline (smaller `val_batch_size`).
+
+---
+
 ## Next Steps
 
 After training is complete:

--- a/octopi/datasets/augment.py
+++ b/octopi/datasets/augment.py
@@ -28,31 +28,6 @@ def get_transforms():
         Orientationd(keys=["image", "label"], axcodes="RAS")
     ])
 
-def _pos_neg_from_bg_ratio(bg_ratio: float, max_pos: int = 9):
-    """
-
-    Input:
-        bg_ratio: float in (0, 1]
-        max_pos: int, maximum number of positive samples
-
-    bg_ratio in (0, 1]
-      bg_ratio = 1.0 -> pos=1, neg=1  (50/50)
-      bg_ratio = 0.5 -> pos=2, neg=1  (66/33)
-      bg_ratio = 0.25-> pos=4, neg=1  (80/20)   
-      smaller bg_ratio -> higher pos relative to neg (more foreground bias)
-
-    max_pos caps the foreground weight so bg_ratio near 0 doesn't explode.
-    """
-    if not (0.0 < bg_ratio <= 1.0):
-        raise ValueError(f"bg_ratio must be in (0, 1], got {bg_ratio}")
-
-    neg = 1
-    pos = int(round(1.0 / bg_ratio))
-
-    # clamp to avoid absurd ratios
-    pos = max(1, min(pos, max_pos))
-    return pos, neg
-
 def get_random_transforms( input_dim, num_samples, Nclasses, bg_ratio: float = 0.0):
     """
     Input:
@@ -72,26 +47,17 @@ def get_random_transforms( input_dim, num_samples, Nclasses, bg_ratio: float = 0
     if not (0.0 <= bg_ratio <= 1.0):
         raise ValueError(f"bg_ratio must be in [0,1], got {bg_ratio}")
 
-    # Determine the cropping strategy based on bg_ratio
-    if bg_ratio: 
-        # Mixed pos/neg crops: include some background (neg) 
-        # but never more than foreground (pos)    
-        pos, neg = _pos_neg_from_bg_ratio(bg_ratio)
-        crop = RandCropByPosNegLabeld(
-            keys=['image', 'label'],
-            label_key="label",
-            spatial_size=[input_dim[0], input_dim[1], input_dim[2]],     
-            pos=pos, neg=neg,
-            num_samples=num_samples
-        )
-    else: # Provide Crops Based on Label Classes
-        crop = RandCropByLabelClassesd(
-            keys=["image", "label"],
-            label_key="label",
-            spatial_size=[input_dim[0], input_dim[1], input_dim[2]],     
-            num_classes=Nclasses,
-            num_samples=num_samples
-        )
+    # bg_ratio controls background fraction; foreground classes are sampled equally
+    if bg_ratio > 0:
+        fg_ratio = (1 - bg_ratio) / (Nclasses - 1)
+        ratios = [bg_ratio] + [fg_ratio] * (Nclasses - 1)
+    else:
+        ratios = None  # equal sampling across all classes
+    crop = RandCropByLabelClassesd(
+        keys=["image", "label"], label_key="label",
+        spatial_size=[input_dim[0], input_dim[1], input_dim[2]],
+        num_classes=Nclasses, num_samples=num_samples, ratios=ratios
+    )
 
     # Random Affine Transform
     rot = RandAffined(

--- a/octopi/datasets/generators.py
+++ b/octopi/datasets/generators.py
@@ -1,4 +1,7 @@
-from monai.data import DataLoader, SmartCacheDataset, CacheDataset, Dataset
+from monai.data import (
+    DataLoader, SmartCacheDataset, CacheDataset,
+    GridPatchDataset, PatchIterd, pad_list_data_collate
+)
 from octopi.datasets import helpers as utils
 from monai.transforms import Compose
 from octopi.datasets import augment
@@ -103,7 +106,7 @@ class CopickDataModule:
         num_samples: int = 64,
         train_transforms: Compose = None,
         val_transforms: Compose = None,
-        val_batch_size: int = 1
+        val_batch_size: int = 128
         ):
         """
         Create the training and validation datasets and return the DataLoaders.
@@ -170,22 +173,22 @@ class CopickDataModule:
             for alg in algs
         ]
 
-        # Default Val Transforms for Particle Picking
-        if val_transforms is None:
-            val_transforms = augment.get_transforms()
+        # Load full volumes, then GridPatchDataset yields one patch at a time
+        # so the DataLoader can batch val_batch_size patches per iteration.
+        # PatchIterd yields (patch_dict, coords) tuples as GridPatchDataset expects.
+        roi = max(128, crop_size)
+        base_val_ds = CacheDataset(data=val_files, transform=augment.get_transforms(), cache_rate=1.0, num_workers=4)
+        patch_iter = PatchIterd(
+            keys=["image", "label"],
+            patch_size=(roi, roi, roi),
+            mode="constant"
+        )
+        val_ds = GridPatchDataset(data=base_val_ds, patch_iter=patch_iter, with_coordinates=False)
 
-        # Create the CacheDataset
-        val_ds = Dataset(
-            data=val_files,                
-            transform=val_transforms,
-            # cache_rate=1.0,          # cache all val items
-            # num_workers=8,           # threads for initial caching
-        )   
-
-        # Create the DataLoader
         val_loader = DataLoader(
-            val_ds, batch_size=val_batch_size, 
-            shuffle=False, num_workers=0, 
+            val_ds, batch_size=val_batch_size,
+            shuffle=False, num_workers=4,
+            collate_fn=pad_list_data_collate,
             pin_memory=torch.cuda.is_available()
         )
 
@@ -365,7 +368,7 @@ class MultiCopickDataModule:
         num_samples: int = 64,
         train_transforms: Compose = None,
         val_transforms: Compose = None,
-        val_batch_size: int = 1,
+        val_batch_size: int = 128,
         ):
         """
         Create the training and validation datasets and return the DataLoaders.
@@ -420,22 +423,22 @@ class MultiCopickDataModule:
             for alg in algs                
         ]
 
-        # Default Val Transforms for Particle Picking
-        if val_transforms is None:
-            val_transforms = augment.get_transforms()
+        # Load full volumes, then GridPatchDataset yields one patch at a time
+        # so the DataLoader can batch val_batch_size patches per iteration.
+        # PatchIterd yields (patch_dict, coords) tuples as GridPatchDataset expects.
+        roi = max(128, crop_size)
+        base_val_ds = CacheDataset(data=val_files, transform=augment.get_transforms(), cache_rate=1.0, num_workers=4)
+        patch_iter = PatchIterd(
+            keys=["image", "label"],
+            patch_size=(roi, roi, roi),
+            mode="constant"
+        )
+        val_ds = GridPatchDataset(data=base_val_ds, patch_iter=patch_iter, with_coordinates=False)
 
-        # Create the CacheDataset
-        val_ds = CacheDataset(
-            data=val_files,                
-            transform=val_transforms,
-            cache_rate=1.0,          # cache all val items
-            num_workers=8,           # threads for initial caching
-        )   
-
-        # Create the DataLoader
         val_loader = DataLoader(
-            val_ds, batch_size=val_batch_size, 
-            shuffle=False, num_workers=0, 
+            val_ds, batch_size=val_batch_size,
+            shuffle=False, num_workers=4,
+            collate_fn=pad_list_data_collate,
             pin_memory=torch.cuda.is_available()
         )
 

--- a/octopi/datasets/generators.py
+++ b/octopi/datasets/generators.py
@@ -106,7 +106,7 @@ class CopickDataModule:
         num_samples: int = 64,
         train_transforms: Compose = None,
         val_transforms: Compose = None,
-        val_batch_size: int = 128
+        val_batch_size: int = 64
         ):
         """
         Create the training and validation datasets and return the DataLoaders.
@@ -158,11 +158,20 @@ class CopickDataModule:
             )
 
         # Create the DataLoader
+        #
+        # persistent_workers=False is deliberate: with CacheDataset the
+        # tomogram cache lives in the main process and is shared to workers
+        # via copy-on-write. Over many epochs, workers drift toward their
+        # own full copy of the cache (~cache_size per worker), which can
+        # OOM on large worker counts. Re-forking each epoch resets COW.
+        train_nw = utils.auto_num_workers()
         train_loader = DataLoader(
-            self.train_ds, batch_size=1, 
-            shuffle=True, num_workers=4, 
+            self.train_ds, batch_size=1,
+            shuffle=True, num_workers=train_nw,
+            persistent_workers=False,
+            prefetch_factor=4 if train_nw > 0 else None,
             pin_memory=torch.cuda.is_available()
-        )         
+        )
 
         # Create the list of validation files
         val_files = [
@@ -185,9 +194,16 @@ class CopickDataModule:
         )
         val_ds = GridPatchDataset(data=base_val_ds, patch_iter=patch_iter, with_coordinates=False)
 
+        # Validation is infrequent and its per-batch tensors are large
+        # (val_batch_size patches at ~roi³). Use fewer workers, default
+        # prefetch, and NO persistent_workers so memory is reclaimed
+        # between validations — otherwise val workers hold GBs of prefetch
+        # idle for all the training epochs between val_interval runs.
+        val_nw = max(1, train_nw // 4)
         val_loader = DataLoader(
             val_ds, batch_size=val_batch_size,
-            shuffle=False, num_workers=4,
+            shuffle=False, num_workers=val_nw,
+            persistent_workers=False,
             collate_fn=pad_list_data_collate,
             pin_memory=torch.cuda.is_available()
         )
@@ -368,7 +384,7 @@ class MultiCopickDataModule:
         num_samples: int = 64,
         train_transforms: Compose = None,
         val_transforms: Compose = None,
-        val_batch_size: int = 128,
+        val_batch_size: int = 64,
         ):
         """
         Create the training and validation datasets and return the DataLoaders.
@@ -406,11 +422,20 @@ class MultiCopickDataModule:
         )
 
         # Create the DataLoader
+        #
+        # persistent_workers=False is deliberate: with CacheDataset the
+        # tomogram cache lives in the main process and is shared to workers
+        # via copy-on-write. Over many epochs, workers drift toward their
+        # own full copy of the cache (~cache_size per worker), which can
+        # OOM on large worker counts. Re-forking each epoch resets COW.
+        train_nw = utils.auto_num_workers()
         train_loader = DataLoader(
-            self.train_ds, batch_size=1, 
-            shuffle=True, num_workers=8, 
+            self.train_ds, batch_size=1,
+            shuffle=True, num_workers=train_nw,
+            persistent_workers=False,
+            prefetch_factor=4 if train_nw > 0 else None,
             pin_memory=torch.cuda.is_available()
-        )         
+        )
 
         # Create the list of validation files
         val_files = [
@@ -435,9 +460,16 @@ class MultiCopickDataModule:
         )
         val_ds = GridPatchDataset(data=base_val_ds, patch_iter=patch_iter, with_coordinates=False)
 
+        # Validation is infrequent and its per-batch tensors are large
+        # (val_batch_size patches at ~roi³). Use fewer workers, default
+        # prefetch, and NO persistent_workers so memory is reclaimed
+        # between validations — otherwise val workers hold GBs of prefetch
+        # idle for all the training epochs between val_interval runs.
+        val_nw = max(1, train_nw // 4)
         val_loader = DataLoader(
             val_ds, batch_size=val_batch_size,
-            shuffle=False, num_workers=4,
+            shuffle=False, num_workers=val_nw,
+            persistent_workers=False,
             collate_fn=pad_list_data_collate,
             pin_memory=torch.cuda.is_available()
         )

--- a/octopi/datasets/generators.py
+++ b/octopi/datasets/generators.py
@@ -141,8 +141,8 @@ class CopickDataModule:
             self.train_ds = SmartCacheDataset(
                 data=train_files,                
                 transform=train_transforms,
-                cache_num=self.tomo_batch_size,  # e.g. 8–64 volumes
-                replace_rate=0.3,                # e.g. 0.2–0.3
+                cache_num=self.tomo_batch_size,  
+                replace_rate=0.15,               
                 num_init_workers=8,
                 num_replace_workers=8,
                 shuffle=False,
@@ -395,8 +395,8 @@ class MultiCopickDataModule:
         self.train_ds = SmartCacheDataset(
             data=train_files,                
             transform=train_transforms,
-            cache_num=self.tomo_batch_size,  # e.g. 8–64 volumes
-            replace_rate=0.3,                # e.g. 0.2–0.3
+            cache_num=self.tomo_batch_size,  
+            replace_rate=0.15,               
             num_init_workers=8,
             num_replace_workers=8,
             shuffle=False,

--- a/octopi/datasets/helpers.py
+++ b/octopi/datasets/helpers.py
@@ -1,6 +1,26 @@
 from octopi.datasets import io as dio
 from collections.abc import Mapping
 from octopi.utils import io as io
+import os
+
+def auto_num_workers(cap: int = 16, min_workers: int = 1) -> int:
+    """
+    Pick a DataLoader worker count that respects the CPUs actually available
+    to this process.
+
+    On Linux this uses ``os.sched_getaffinity`` so SLURM ``--cpus-per-task``
+    bindings are honoured. Elsewhere it falls back to ``os.cpu_count``. The
+    result is clamped to ``cap`` since past ~16 workers gains are usually
+    noise for a 3D UNet with cached datasets, and each worker adds ~1-2 GB
+    of RAM overhead.
+
+    The cap only clamps from above: a 4-core laptop still gets 4 workers.
+    """
+    try:
+        n = len(os.sched_getaffinity(0))
+    except AttributeError:
+        n = 4 # default to small number on non-slurm platforms
+    return max(min_workers, min(cap, n))
 
 def scan_runs(
     *,

--- a/octopi/entry_points/run_optuna.py
+++ b/octopi/entry_points/run_optuna.py
@@ -35,7 +35,7 @@ import rich_click as click
               help="Submit trials via SLURM (submitit) instead of local GPUs")
 @click.option('--njobs', '-nj', type=int, default=5,
               help="Number of concurrent training jobs when using submitit")
-@click.option('--cpu-constraint', '-cc', type=str, default='4,16',
+@click.option('--cpu-constraint', '-cc', type=str, default='16,8',
               help='Number of CPUs and mem-per-cpu to requested. (e.g., "4,16" for 4 CPUs and 16GB per CPU)')
 @click.option('--gpu-constraint', '-gc', type=str, default=None,
               help='GPU constraint to use for SLURM jobs (e.g., "a6000" or "l40,a6000")')

--- a/octopi/pytorch/search.py
+++ b/octopi/pytorch/search.py
@@ -55,7 +55,7 @@ class ModelExplorer:
         sizes = [64, 80, 96, 112, 128, 144, 160]
         self.sampling = {
             'crop_size': trial.suggest_categorical("crop_size", sizes),
-            'num_samples': trial.suggest_categorical("num_samples", [4, 8, 16, 24])
+            'num_samples': trial.suggest_categorical("num_samples", [4, 8, 16, 24, 32, 48])
         }
         self.config['dim_in'] = self.sampling['crop_size']
 

--- a/octopi/pytorch/search.py
+++ b/octopi/pytorch/search.py
@@ -55,7 +55,7 @@ class ModelExplorer:
         sizes = [64, 80, 96, 112, 128, 144, 160]
         self.sampling = {
             'crop_size': trial.suggest_categorical("crop_size", sizes),
-            'num_samples': trial.suggest_categorical("num_samples", [2, 4, 8, 16])
+            'num_samples': trial.suggest_categorical("num_samples", [4, 8, 16, 24])
         }
         self.config['dim_in'] = self.sampling['crop_size']
 

--- a/octopi/pytorch/search_helper.py
+++ b/octopi/pytorch/search_helper.py
@@ -209,9 +209,15 @@ def run_one_trial(storage_url: str, study_name: str, submit_kwargs: dict):
     walltime_event = threading.Event()
 
     # Define signal handler and register it
-    def _on_sigusr2(signum, frame):
+    # SIGUSR1: SLURM pre-timeout warning (via --signal USR1@N)
+    # SIGUSR2: legacy / manual
+    # SIGTERM: SLURM hard cancellation (time limit, scancel)
+    def _on_walltime(signum, frame):
+        print(f"[Trial] Received signal {signum} — setting walltime event for graceful stop.", flush=True)
         walltime_event.set()
-    signal.signal(signal.SIGUSR2, _on_sigusr2)
+    signal.signal(signal.SIGUSR1, _on_walltime)
+    signal.signal(signal.SIGUSR2, _on_walltime)
+    signal.signal(signal.SIGTERM, _on_walltime)
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     if torch.cuda.is_available():

--- a/octopi/pytorch/submit_search.py
+++ b/octopi/pytorch/submit_search.py
@@ -311,6 +311,7 @@ class SubmititExplorer(ExploreSubmitter):
             slurm_mem_per_cpu=f"{self.mem_per_cpu_gb}G",
             slurm_additional_parameters={
                 "gpus": "1",
+                "signal": f"USR1@180", # Send SIGUSR1 3 minutes before timeout (for graceful shutdown)
             },
         )
         if self.gpu_constraint: # Optional GPU Constraint

--- a/octopi/pytorch/submit_search.py
+++ b/octopi/pytorch/submit_search.py
@@ -302,16 +302,27 @@ class SubmititExplorer(ExploreSubmitter):
         log_dir = os.path.join(submit_kwargs["output"], self.submitit_folder)
         os.makedirs(log_dir, exist_ok=True)
         executor = submitit.AutoExecutor(folder=log_dir)
+
+        # When submitting from inside a SLURM allocation (interactive/compute node),
+        # parent env vars leak into child jobs and can conflict with srun.
+        inside_allocation = "SLURM_JOB_ID" in os.environ
+        setup = [
+            "unset SLURM_MEM_PER_GPU SLURM_MEM_PER_NODE",
+            "unset SLURM_NTASKS SLURM_NTASKS_PER_NODE SLURM_TASKS_PER_NODE",
+            "export SLURM_EXPORT_ENV=ALL",
+        ] if inside_allocation else []
+
         executor.update_parameters(
             slurm_partition="gpu",
-            slurm_use_srun = False,
+            slurm_use_srun=True,
             slurm_job_name=study_name,
             timeout_min=self.slurm_timeout_min,
             cpus_per_task=self.slurm_cpus_per_task,
             slurm_mem_per_cpu=f"{self.mem_per_cpu_gb}G",
+            slurm_setup=setup,
             slurm_additional_parameters={
                 "gpus": "1",
-                "signal": f"USR1@180", # Send SIGUSR1 3 minutes before timeout (for graceful shutdown)
+                "signal": "USR1@180", # SIGUSR1 3 min before timeout (for graceful shutdown)
             },
         )
         if self.gpu_constraint: # Optional GPU Constraint

--- a/octopi/pytorch/train_helper.py
+++ b/octopi/pytorch/train_helper.py
@@ -1,0 +1,22 @@
+import torch
+
+def auto_amp(device: torch.device):
+    """
+    Pick the best mixed-precision config for the current device.
+
+    Returns (enabled, dtype, scaler):
+      - Ampere+ (H100/H200, A100, RTX 30xx/40xx, RTX Axxxx): bf16, no scaler.
+      - Volta/Turing (V100, T4, RTX 20xx):                   fp16 + GradScaler.
+      - Pascal or older, CPU, MPS:                           fp32, disabled.
+    """
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return False, torch.float32, None
+
+    if torch.cuda.is_bf16_supported():
+        return True, torch.bfloat16, None
+
+    major, _ = torch.cuda.get_device_capability(device)
+    if major >= 7:
+        return True, torch.float16, torch.amp.GradScaler("cuda")
+
+    return False, torch.float32, None

--- a/octopi/pytorch/trainer.py
+++ b/octopi/pytorch/trainer.py
@@ -83,52 +83,36 @@ class ModelTrainer:
     @torch.no_grad()
     def validate_update(self):
         """
-        Perform validation and compute metrics, including validation loss.
-        """        
-
-        # Set model to evaluation mode
+        Validate patch-by-patch. GridPatchDataset yields individual patches so
+        the DataLoader batches them directly — no manual sub-batching needed.
+        """
         self.model.eval()
         val_loss = 0
-        with torch.amp.autocast(device_type="cuda", dtype=torch.float16):
-            for val_data in self.val_loader:
-                val_inputs = val_data["image"].to(self.device)
-                val_labels = val_data["label"].to(self.device) 
-                
-                # Apply sliding window inference
-                roi = max(128, self.crop_size)  # try setting a set size of 128, 144 or 160?
-                val_outputs = sliding_window_inference(
-                    inputs=val_inputs, 
-                    roi_size=(roi, roi, roi),
-                    sw_batch_size=self.sw_bs,
-                    predictor=self.model, 
-                    overlap=self.overlap,
-                    sw_device=self.device,
-                    device=self.device
-                )
+        n_batches = 0
 
-                del val_inputs
+        for val_data in self.val_loader:
+            batch_in  = val_data["image"].to(self.device)
+            batch_lbl = val_data["label"].to(self.device)
 
-                # Compute the loss for this batch
-                loss = self.loss_function(val_outputs.float(), val_labels)  
-                val_loss += loss.item()  # Accumulate the loss                
+            with torch.amp.autocast(device_type="cuda", dtype=torch.float16):
+                batch_out = self.model(batch_in)
 
-                # Apply post-processing
-                metric_val_outputs = [self.post_pred(i) for i in decollate_batch(val_outputs)]
-                metric_val_labels = [self.post_label(i) for i in decollate_batch(val_labels)]                             
-                
-                # Compute metrics
-                self.metrics_function(y_pred=metric_val_outputs, y=metric_val_labels)             
+            loss = self.loss_function(
+                batch_out.float().detach().cpu(),
+                batch_lbl.detach().cpu()
+            )
+            val_loss += loss.item()
+            n_batches += 1
 
-                del val_labels, val_outputs, metric_val_outputs, metric_val_labels
-            torch.cuda.empty_cache()
+            m_out = [self.post_pred(i) for i in decollate_batch(batch_out)]
+            m_lbl = [self.post_label(i) for i in decollate_batch(batch_lbl)]
+            self.metrics_function(y_pred=m_out, y=m_lbl)
 
-        # # Contains recall, precision, and f1 for each class
+            del batch_in, batch_lbl, batch_out, m_out, m_lbl
+
         metric_values = self.metrics_function.aggregate(reduction='mean_batch')
-
-        # Compute average validation loss and add to metrics dictionary
-        val_loss /= len(self.val_loader)
+        val_loss /= max(n_batches, 1)
         metric_values.append(val_loss)
-
         return metric_values
 
     def train(

--- a/octopi/pytorch/trainer.py
+++ b/octopi/pytorch/trainer.py
@@ -1,5 +1,6 @@
 from octopi.utils import visualization_tools as viz
 from monai.inferers import sliding_window_inference
+from octopi.pytorch.train_helper import auto_amp
 from octopi.utils import stopping_criteria
 import torch, os, mlflow, re, optuna, time
 from monai.transforms import AsDiscrete
@@ -39,6 +40,16 @@ class ModelTrainer:
         if self.ema_experiment:
             self.ema_handler = ema.ExponentialMovingAverage(self.model.parameters(), decay=0.995)
 
+        # Mixed precision: bf16 on Ampere+, fp16+GradScaler on Volta/Turing, off otherwise.
+        self.amp_enabled, self.amp_dtype, self.scaler = auto_amp(self.device)
+
+        # Let TF32 accelerate fp32 matmuls on Ampere+, and let cuDNN pick the
+        # fastest conv algorithm for this input shape (shapes are fixed here
+        # since we crop to a constant patch size).
+        if self.device.type == "cuda":
+            torch.set_float32_matmul_precision("high")
+            torch.backends.cudnn.benchmark = True
+
         # Initialize Figure and Axes for Plotting
         self.fig = None; self.axs = None
 
@@ -61,13 +72,25 @@ class ModelTrainer:
         self.model.train()
         for batch_data in self.train_loader:
             step += 1
-            inputs = batch_data["image"].to(self.device)  # Shape: [B, C, H, W, D]
-            labels = batch_data["label"].to(self.device)  # Shape: [B, C, H, W, D]
-            self.optimizer.zero_grad()
-            outputs = self.model(inputs)    # Output shape: [B, num_classes, H, W, D] 
-            loss = self.loss_function(outputs, labels)
-            loss.backward()
-            self.optimizer.step()
+            inputs = batch_data["image"].to(self.device, non_blocking=True)  # [B, C, H, W, D]
+            labels = batch_data["label"].to(self.device, non_blocking=True)  # [B, C, H, W, D]
+            self.optimizer.zero_grad(set_to_none=True)
+
+            with torch.amp.autocast(
+                device_type=self.device.type,
+                dtype=self.amp_dtype,
+                enabled=self.amp_enabled,
+            ):
+                outputs = self.model(inputs)    # [B, num_classes, H, W, D]
+                loss = self.loss_function(outputs, labels)
+
+            if self.scaler is not None:
+                self.scaler.scale(loss).backward()
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
+            else:
+                loss.backward()
+                self.optimizer.step()
 
             # Update EMA weights
             if self.ema_experiment:
@@ -91,16 +114,21 @@ class ModelTrainer:
         n_batches = 0
 
         for val_data in self.val_loader:
-            batch_in  = val_data["image"].to(self.device)
-            batch_lbl = val_data["label"].to(self.device)
+            batch_in  = val_data["image"].to(self.device, non_blocking=True)
+            batch_lbl = val_data["label"].to(self.device, non_blocking=True)
 
-            with torch.amp.autocast(device_type="cuda", dtype=torch.float16):
+            with torch.amp.autocast(
+                device_type=self.device.type,
+                dtype=self.amp_dtype,
+                enabled=self.amp_enabled,
+            ):
                 batch_out = self.model(batch_in)
 
-            loss = self.loss_function(
-                batch_out.float().detach().cpu(),
-                batch_lbl.detach().cpu()
-            )
+            # Keep loss computation on GPU: the old path did a round-trip to
+            # CPU per batch (~2-4 GB transfer) and forced a GPU sync, which
+            # was the dominant cost of validation. .float() upcasts bf16/fp16
+            # output to fp32 for numeric stability in TverskyLoss.
+            loss = self.loss_function(batch_out.float(), batch_lbl)
             val_loss += loss.item()
             n_batches += 1
 


### PR DESCRIPTION
Summary
         
- Automatic mixed precision (`octopi/pytorch/train_helper.py`, `trainer.py`): new `auto_amp()` picks `bf16` on Ampere+, fp16+GradScaler on Volta/Turing, fp32 elsewhere. Also enables TF32 matmul  
  and cudnn.benchmark.
  - Auto-sized DataLoader workers (`octopi/datasets/helpers.py`): new `auto_num_workers()` reads `os.sched_getaffinity(0)` so SLURM `--cpus-per-task` is honoured, capped at 16. Replaces hardcoded  
  num_workers=4/8.                                                                                                                                                                           
  - Validation rewrite (`octopi/datasets/generators.py`, `trainer.py`): replaces per-tomogram sliding_window_inference with GridPatchDataset + PatchIterd. Patches are now batched through the
  DataLoader at val_batch_size=64 (was 1), and loss stays on-GPU instead of round-tripping to CPU per batch. This was the dominant cost of validation on large tomograms.                    
  - Copy-on-write memory hygiene: persistent_workers=False is now deliberate (with a comment explaining why), and SmartCacheDataset.replace_rate drops from 0.3 → 0.15 to reduce worker drift
   on large caches.                                                                                                                                                                          
  - Crop sampling simplified (octopi/datasets/augment.py): drops the dual RandCropByPosNegLabeld / RandCropByLabelClassesd branch and _pos_neg_from_bg_ratio helper. bg_ratio > 0 now maps
  directly to class ratios on RandCropByLabelClassesd; foreground classes are sampled equally.                                                                                               
  - Graceful SLURM shutdown (octopi/pytorch/search_helper.py, submit_search.py): trials now handle SIGUSR1 (pre-timeout via --signal USR1@180) and SIGTERM in addition to SIGUSR2, so Optuna
  trials can finish the current epoch before SLURM cancels them.                                                                                                                             
  - Hyperparameter-search defaults: run_optuna.py default --cpu-constraint → 16,8; search.py num_samples search space broadened to [4, 8, 16, 24, 32, 48].