### PR TITLE
feat: Add MCP server for Claude integration

### DIFF
--- a/docs/user-guide/claude-code-mcp.md
+++ b/docs/user-guide/claude-code-mcp.md
@@ -1,0 +1,157 @@
+# Claude Code / Claude Desktop Integration
+
+`octopi mcp` starts a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that connects Claude Code or Claude Desktop directly to your cryo-ET particle picking workflows. Claude can look up command options, suggest fully-formed CLI invocations, and run fast processing steps — all from a conversation.
+
+---
+
+## What Claude Can Do
+
+Once connected, Claude has access to the full octopi CLI through these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `list_octopi_commands` | Browse all exposed commands and their descriptions |
+| `get_command_help` | Fetch the full `--help` output for any command |
+| `run_octopi_command` | Execute an octopi command directly |
+
+!!! info "Default behaviour: suggest, not run"
+    By default Claude will give you the exact command to copy and paste — you stay in control of what runs and when. If you'd prefer Claude to run a command directly, just ask: *"go ahead and run it"*.
+
+    For long-running GPU jobs (`train`, `model-explore`, `segment`), Claude always hands off to you regardless — it prints the command for you to run, with all flags filled in.
+
+---
+
+## Setup
+
+Install the `mcp` extras first:
+
+```bash
+pip install "octopi[mcp]"
+```
+
+Then run `octopi mcp install` once from the terminal. It automatically registers the server in the right config file — you never need to start the server manually.
+
+=== "Claude Code (project)"
+
+    Registers octopi for the current directory only. Other projects won't see it.
+
+    ```bash
+    cd /path/to/your/project
+    octopi mcp install
+    ```
+
+    This creates a `.mcp.json` file in the current directory. Open Claude Code in that directory and the server connects automatically.
+
+=== "Claude Code (global)"
+
+    Registers octopi for all Claude Code sessions on this machine.
+
+    ```bash
+    octopi mcp install --target code-global
+    ```
+
+    Start a new Claude Code session to pick up the change.
+
+=== "Claude Desktop"
+
+    ```bash
+    octopi mcp install --target desktop
+    ```
+
+    Restart Claude Desktop to pick up the change.
+
+You can verify the registration at any time:
+
+```bash
+octopi mcp status                        # check project-level
+octopi mcp status --target code-global   # check global
+```
+
+To remove it:
+
+```bash
+octopi mcp uninstall --server-name octopi
+```
+
+---
+
+## Example Workflow
+
+A full particle picking run — from coordinates to evaluated picks — guided by Claude:
+
+**Step 1 — Create segmentation targets**
+
+> *"Create segmentation targets from my CoPick project. Config is at /data/config.json, particle name is ribosome."*
+
+Claude suggests (or runs):
+
+```bash
+octopi create-targets \
+    --config /data/config.json \
+    --target ribosome \
+    --voxel-size 10
+```
+
+**Step 2 — Explore model architectures**
+
+> *"Run a Bayesian architecture search. I have 4 GPUs available."*
+
+Claude suggests:
+
+```bash
+octopi model-explore \
+    --config /data/config.json \
+    --target-info targets,octopi,1 \
+    --voxel-size 10 \
+    --model-type Unet \
+    --num-trials 50 \
+    --output explore_results
+```
+
+!!! tip "SLURM support"
+    Add `--submitit --njobs 5 --gpu-constraint a6000` to distribute trials across SLURM nodes instead of running them locally.
+
+**Step 3 — Segment tomograms**
+
+> *"Segment all my tomograms using the best model from the search."*
+
+Claude suggests:
+
+```bash
+octopi segment \
+    --config /data/config.json \
+    --model-config explore_results/best_model_config.yaml \
+    --model-weights explore_results/best_model.pt \
+    --voxel-size 10 \
+    --seg-info predict,octopi,1
+```
+
+**Step 4 — Localize particles**
+
+> *"Extract coordinates from the segmentation."*
+
+Claude suggests (or runs):
+
+```bash
+octopi localize \
+    --config /data/config.json \
+    --seg-info predict,octopi,1 \
+    --voxel-size 10 \
+    --method watershed \
+    --pick-user-id octopi \
+    --pick-session-id 1
+```
+
+**Step 5 — Evaluate (optional)**
+
+> *"Evaluate against ground truth from user 'expert'."*
+
+Claude runs:
+
+```bash
+octopi evaluate \
+    --config /data/config.json \
+    --ground-truth-user-id expert \
+    --predict-user-id octopi \
+    --predict-session-id 1
+```

--- a/docs/user-guide/claude-code-mcp.md
+++ b/docs/user-guide/claude-code-mcp.md
@@ -93,6 +93,14 @@ Then run `octopi mcp install` once from the terminal. It automatically registers
 
     Restart Claude Desktop to pick up the change.
 
+!!! tip "Also install copick-mcp"
+    For the best experience, also install [copick-mcp](https://github.com/copick/copick-mcp). It gives Claude direct access to your CoPick project — runs, picks, segmentations, and tomograms — so it can inspect your data as it guides you through the workflow.
+
+    ```bash
+    copick setup mcp --target code-global   # all Claude Code sessions
+    copick setup mcp --target code-project  # current directory only
+    ```
+
 You can verify the registration at any time:
 
 ```bash

--- a/docs/user-guide/claude-code-mcp.md
+++ b/docs/user-guide/claude-code-mcp.md
@@ -6,18 +6,51 @@
 
 ## What Claude Can Do
 
-Once connected, Claude has access to the full octopi CLI through these tools:
+Once connected, you can describe what you want in plain language and Claude handles the rest:
 
-| Tool | Purpose |
-|------|---------|
-| `list_octopi_commands` | Browse all exposed commands and their descriptions |
-| `get_command_help` | Fetch the full `--help` output for any command |
-| `run_octopi_command` | Execute an octopi command directly |
+<div class="grid cards" markdown>
 
-!!! info "Default behaviour: suggest, not run"
-    By default Claude will give you the exact command to copy and paste — you stay in control of what runs and when. If you'd prefer Claude to run a command directly, just ask: *"go ahead and run it"*.
+-   :material-sitemap:{ .lg .middle } **Guide the full workflow**
 
-    For long-running GPU jobs (`train`, `model-explore`, `segment`), Claude always hands off to you regardless — it prints the command for you to run, with all flags filled in.
+    ---
+
+    Walks you through create-targets → train/model-explore → segment → localize → evaluate, asking only for what it needs.
+
+-   :material-flag-checkered:{ .lg .middle } **Fill in the flags**
+
+    ---
+
+    Looks up the correct options for every command so you don't have to memorise them.
+
+-   :material-link-variant:{ .lg .middle } **Understand URI shorthand**
+
+    ---
+
+    Accepts tomogram, segmentation, and pick URIs directly in your prompt and translates them to the right CLI flags.
+
+-   :material-lightning-bolt:{ .lg .middle } **Run fast steps for you**
+
+    ---
+
+    Executes `create-targets`, `localize`, `evaluate`, and `membrane-extract` directly and reports back.
+
+-   :material-chip:{ .lg .middle } **Hand off GPU jobs**
+
+    ---
+
+    For `train`, `model-explore`, and `segment`, prints a ready-to-run command block for you to submit yourself.
+
+</div>
+
+!!! info "You stay in control"
+    Claude suggests commands rather than running them by default — you copy, review, and paste. For fast, non-destructive commands you can say *"go ahead and run it"* to skip the copy-paste step. GPU-intensive jobs (`train`, `model-explore`, `segment`) are always handed off regardless.
+
+??? note "MCP tools used under the hood"
+    | Tool | Purpose |
+    |------|---------|
+    | `list_octopi_commands` | Browse all exposed commands and their descriptions |
+    | `get_command_help` | Fetch the full `--help` output for any command |
+    | `run_octopi_command` | Execute an octopi command directly |
 
 ---
 
@@ -81,20 +114,35 @@ A full particle picking run — from coordinates to evaluated picks — guided b
 
 **Step 1 — Create segmentation targets**
 
-> *"Create segmentation targets from my CoPick project. Config is at /data/config.json, particle name is ribosome."*
+> *"Help me create segmentation targets from my CoPick project at /data/config.json. I want targets for ribosome:manual/1, virus-like-particle:tm/2, and membranes:membrane-seg/1."*
 
 Claude suggests (or runs):
 
 ```bash
 octopi create-targets \
     --config /data/config.json \
-    --target ribosome \
+    --target ribosome,manual,1 \
+    --target virus-like-particle,tm,2 \
+    --target membranes,membrane-seg,1 \
     --voxel-size 10
 ```
 
+??? tip "URI shorthand for tomograms, segmentations, and picks"
+    Throughout the workflow you can refer to data resources using compact URI strings rather than spelling out individual flags. Claude understands both formats.
+
+    | Resource | URI format | Example |
+    |----------|-----------|---------|
+    | Tomogram | `algorithm@voxel_spacing` | `wbp@10.0` |
+    | Segmentation | `name:user_id/session_id` | `predict:octopi/1` |
+    | Picks / targets | `name:user_id/session_id` | `ribosome:manual/1` |
+
+    Multiple picks or segmentation targets can be listed together:
+
+    > *"… targets for ribosome:manual/1, virus-like-particle:tm/2, and membranes:membrane-seg/1"*
+
 **Step 2 — Explore model architectures**
 
-> *"Run a Bayesian architecture search. I have 4 GPUs available."*
+> *"Run a Bayesian architecture search on those targets (targets:octopi/1). I'm on a SLURM cluster — distribute 50 trials across 5 jobs, constrained to a6000 GPUs."*
 
 Claude suggests:
 
@@ -105,15 +153,15 @@ octopi model-explore \
     --voxel-size 10 \
     --model-type Unet \
     --num-trials 50 \
-    --output explore_results
+    --output explore_results \
+    --submitit \
+    --njobs 5 \
+    --gpu-constraint a6000
 ```
-
-!!! tip "SLURM support"
-    Add `--submitit --njobs 5 --gpu-constraint a6000` to distribute trials across SLURM nodes instead of running them locally.
 
 **Step 3 — Segment tomograms**
 
-> *"Segment all my tomograms using the best model from the search."*
+> *"Segment all tomograms (wbp@10.0) with the best model from the search. Save predictions as predict:octopi/1."*
 
 Claude suggests:
 
@@ -122,29 +170,28 @@ octopi segment \
     --config /data/config.json \
     --model-config explore_results/best_model_config.yaml \
     --model-weights explore_results/best_model.pt \
-    --voxel-size 10 \
-    --seg-info predict,octopi,1
+    --tomo-uri wbp@10.0 \
+    --seg-uri predict:octopi/1
 ```
 
 **Step 4 — Localize particles**
 
-> *"Extract coordinates from the segmentation."*
+> *"Extract particle coordinates from predict:octopi/1 using watershed. Save picks with session 2."*
 
 Claude suggests (or runs):
 
 ```bash
 octopi localize \
     --config /data/config.json \
-    --seg-info predict,octopi,1 \
-    --voxel-size 10 \
+    --seg-uri predict:octopi/1 \
     --method watershed \
     --pick-user-id octopi \
-    --pick-session-id 1
+    --pick-session-id 2
 ```
 
 **Step 5 — Evaluate (optional)**
 
-> *"Evaluate against ground truth from user 'expert'."*
+> *"Evaluate my picks (octopi, session 1) against the ground truth annotations from user 'expert'."*
 
 Claude runs:
 

--- a/octopi/main.py
+++ b/octopi/main.py
@@ -10,6 +10,7 @@ from octopi.entry_points.run_segment import cli as inference
 from octopi.entry_points.run_localize import cli as localize
 from octopi.entry_points.run_evaluate import cli as evaluate
 from octopi.entry_points.run_extract_mb_picks import cli as mb_extract
+from octopi.mcp.cli import mcp_cli
 
 @click.group(context_settings=cli_context)
 def routines():
@@ -25,12 +26,7 @@ routines.add_command(localize)
 routines.add_command(model_explore)
 routines.add_command(evaluate)
 routines.add_command(mb_extract)
-
-try: 
-    from octopi.mcp.cli import mcp_cli
-    routines.add_command(mcp_cli)
-except ImportError:
-    pass
+routines.add_command(mcp_cli)
 
 @click.group(context_settings=cli_context)
 def slurm_routines():

--- a/octopi/main.py
+++ b/octopi/main.py
@@ -26,6 +26,12 @@ routines.add_command(model_explore)
 routines.add_command(evaluate)
 routines.add_command(mb_extract)
 
+try: 
+    from octopi.mcp.cli import mcp_cli
+    routines.add_command(mcp_cli)
+except ImportError:
+    pass
+
 @click.group(context_settings=cli_context)
 def slurm_routines():
     """Slurm-Octopi 🐙: 🛠️ Tools for Finding Proteins in 🧊 cryo-ET data"""

--- a/octopi/mcp/cli.py
+++ b/octopi/mcp/cli.py
@@ -11,7 +11,7 @@ from octopi import cli_context
 
 @click.group(context_settings=cli_context, name="mcp")
 def mcp_cli():
-    """Manage the octopi MCP server and Claude configuration."""
+    """Octopi MCP server and Claude configuration."""
     pass
 
 
@@ -55,20 +55,20 @@ def _target_display(target: str) -> str:
 
 @mcp_cli.command("install")
 @click.option(
-    "--target",
+    "--target", "-t",
     type=click.Choice(["desktop", "code-global", "code-project"]),
     default="code-project",
     show_default=True,
     help="Where to register: Claude Desktop, global Claude Code, or project-specific",
 )
 @click.option(
-    "--project-path",
+    "--project-path", "-p",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
     help="Project directory for --target code-project (defaults to cwd)",
 )
-@click.option("--server-name", default="octopi", show_default=True, help="Name for the MCP server entry")
-@click.option("--python-path", default=None, help="Path to Python executable (defaults to current Python)")
-@click.option("--force", is_flag=True, help="Overwrite existing entry if present")
+@click.option("--server-name", "-n", default="octopi", show_default=True, help="Name for the MCP server entry")
+@click.option("--python-path", "-py", default=None, help="Path to Python executable (defaults to current Python)")
+@click.option("--force", "-f", is_flag=True, help="Overwrite existing entry if present")
 def mcp_install(target: str, project_path: Optional[Path], server_name: str, python_path: Optional[str], force: bool) -> None:
     """Register octopi as an MCP server in Claude Desktop or Claude Code."""
     config_path = _get_config_path(target, project_path)

--- a/octopi/mcp/cli.py
+++ b/octopi/mcp/cli.py
@@ -1,0 +1,214 @@
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Optional
+
+import rich_click as click
+from octopi import cli_context
+
+
+@click.group(context_settings=cli_context, name="mcp")
+def mcp_cli():
+    """Manage the octopi MCP server and Claude configuration."""
+    pass
+
+
+@mcp_cli.command("start", hidden=True)
+@click.option("--transport", type=click.Choice(["stdio", "sse"]), default="stdio", show_default=True, help="MCP transport")
+@click.option("--port", type=int, default=8000, show_default=True, help="Port for SSE transport")
+def mcp_start(transport: str, port: int) -> None:
+    """Start the octopi MCP server (called by Claude — not for direct use)."""
+    from octopi.mcp.server import mcp
+
+    if transport == "sse":
+        mcp.run(transport="sse", port=port)
+    else:
+        mcp.run(transport="stdio")
+
+
+def _get_config_path(target: str, project_path: Optional[Path] = None) -> Path:
+    if target == "code-global":
+        return Path.home() / ".claude.json"
+    elif target == "code-project":
+        base = project_path or Path.cwd()
+        return base / ".mcp.json"
+    else:  # desktop
+        system = platform.system()
+        if system == "Darwin":
+            return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        elif system == "Windows":
+            appdata = os.getenv("APPDATA", "")
+            return Path(appdata) / "Claude" / "claude_desktop_config.json"
+        else:
+            return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def _target_display(target: str) -> str:
+    return {
+        "desktop": "Claude Desktop",
+        "code-global": "Claude Code (global)",
+        "code-project": "Claude Code (project)",
+    }.get(target, target)
+
+
+@mcp_cli.command("install")
+@click.option(
+    "--target",
+    type=click.Choice(["desktop", "code-global", "code-project"]),
+    default="code-project",
+    show_default=True,
+    help="Where to register: Claude Desktop, global Claude Code, or project-specific",
+)
+@click.option(
+    "--project-path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    help="Project directory for --target code-project (defaults to cwd)",
+)
+@click.option("--server-name", default="octopi", show_default=True, help="Name for the MCP server entry")
+@click.option("--python-path", default=None, help="Path to Python executable (defaults to current Python)")
+@click.option("--force", is_flag=True, help="Overwrite existing entry if present")
+def mcp_install(target: str, project_path: Optional[Path], server_name: str, python_path: Optional[str], force: bool) -> None:
+    """Register octopi as an MCP server in Claude Desktop or Claude Code."""
+    config_path = _get_config_path(target, project_path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not python_path:
+        python_path = sys.executable
+
+    config: dict = {}
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            if not force:
+                click.echo(f"Error reading existing config: {e}")
+                click.echo("   Use --force to overwrite.")
+                sys.exit(1)
+            click.echo(f"Warning: existing config unreadable, starting fresh: {e}")
+
+    config.setdefault("mcpServers", {})
+
+    if server_name in config["mcpServers"] and not force:
+        click.echo(f"Server '{server_name}' already registered in {config_path}")
+        click.echo("   Use --force to overwrite or choose a different --server-name.")
+        sys.exit(1)
+
+    config["mcpServers"][server_name] = {
+        "command": python_path,
+        "args": ["-m", "octopi.mcp.server"],
+        "env": {},
+    }
+
+    try:
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+    except OSError as e:
+        click.echo(f"Error writing config: {e}")
+        sys.exit(1)
+
+    target_name = _target_display(target)
+    click.echo(f"Registered '{server_name}' in {target_name}")
+    click.echo(f"   Config: {config_path}")
+    click.echo(f"   Command: {python_path} -m octopi.mcp.server")
+    click.echo()
+    if target == "desktop":
+        click.echo("   Restart Claude Desktop to apply.")
+    elif target == "code-global":
+        click.echo("   Start a new Claude Code session to apply.")
+    else:
+        proj = project_path or Path.cwd()
+        click.echo(f"   Open Claude Code in {proj} to apply.")
+
+
+@mcp_cli.command("status")
+@click.option(
+    "--target",
+    type=click.Choice(["desktop", "code-global", "code-project"]),
+    default="code-project",
+    show_default=True,
+)
+@click.option("--project-path", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
+def mcp_status(target: str, project_path: Optional[Path]) -> None:
+    """Show octopi MCP server registration status."""
+    config_path = _get_config_path(target, project_path)
+    target_name = _target_display(target)
+
+    click.echo(f"MCP status — {target_name}")
+    click.echo(f"  Config: {config_path}")
+    click.echo(f"  Exists: {'yes' if config_path.exists() else 'no'}")
+
+    if not config_path.exists():
+        click.echo()
+        click.echo(f"  Run: octopi mcp install --target {target}")
+        return
+
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        click.echo(f"  Error reading config: {e}")
+        return
+
+    servers = config.get("mcpServers", {})
+    octopi_servers = {k: v for k, v in servers.items() if "octopi" in k.lower()}
+
+    if octopi_servers:
+        for name, entry in octopi_servers.items():
+            cmd = entry.get("command", "?")
+            args = " ".join(entry.get("args", []))
+            click.echo(f"  {name}: {cmd} {args}")
+    else:
+        click.echo("  No octopi MCP server registered")
+        click.echo(f"  Run: octopi mcp install --target {target}")
+
+
+@mcp_cli.command("uninstall")
+@click.option(
+    "--target",
+    type=click.Choice(["desktop", "code-global", "code-project"]),
+    default="code-project",
+    show_default=True,
+)
+@click.option("--project-path", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
+@click.option("--server-name", required=True, help="Name of the MCP server entry to remove")
+@click.option("--force", is_flag=True, help="Skip confirmation prompt")
+def mcp_uninstall(target: str, project_path: Optional[Path], server_name: str, force: bool) -> None:
+    """Remove an octopi MCP server entry from Claude configuration."""
+    config_path = _get_config_path(target, project_path)
+
+    if not config_path.exists():
+        click.echo(f"No config found at {config_path}")
+        sys.exit(1)
+
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        click.echo(f"Error reading config: {e}")
+        sys.exit(1)
+
+    servers = config.get("mcpServers", {})
+    if server_name not in servers:
+        click.echo(f"Server '{server_name}' not found in {config_path}")
+        sys.exit(1)
+
+    if not force:
+        click.confirm(f"Remove '{server_name}' from {_target_display(target)}?", abort=True)
+
+    del servers[server_name]
+
+    try:
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+    except OSError as e:
+        click.echo(f"Error writing config: {e}")
+        sys.exit(1)
+
+    click.echo(f"Removed '{server_name}' from {config_path}")
+    if target == "desktop":
+        click.echo("   Restart Claude Desktop to apply.")
+    else:
+        click.echo("   Start a new Claude Code session to apply.")

--- a/octopi/mcp/server.py
+++ b/octopi/mcp/server.py
@@ -23,10 +23,27 @@ mcp = FastMCP(
 
 Always begin by asking the user what they want to do before proceeding. The typical workflow runs in this order:
 
+URI FORMATS
+  Users express resources using short URI notation. Translate these to CLI flags as follows:
+
+  Tomogram URI  "algorithm@voxel_spacing"   e.g. "wbp@10.0"
+    → --tomo-alg wbp --voxel-size 10.0
+
+  Segmentation URI  "name:user_id/session_id"   e.g. "predict:octopi/1"
+    → --seg-info predict,octopi,1  (comma-separated: name,user_id,session_id)
+
+  Pick/Target URI  "name:user_id/session_id"   e.g. "ribosome:manual/1"
+    → --target ribosome,manual,1  (for create-targets source picks)
+    → --picks-info ribosome,manual,1  (for membrane-extract)
+    → --pick-user-id manual --pick-session-id 1  (for localize output)
+
+  Multiple URIs of the same type are passed as repeated flags, e.g.:
+    --target ribosome,manual,1 --target virus-like-particle,tm,2
+
 STEP 1 — create-targets
   Convert pick coordinates from a CoPick project into 3D segmentation masks (Zarr).
   This is a fast command — you can run it directly.
-  Key params: --config, --target (name or name,user_id,session_id), --voxel-size, --radius-scale
+  Key params: --config, --target (pick URI → name,user_id,session_id), --voxel-size, --radius-scale
 
 STEP 2 — train OR model-explore
   train: Train a 3D U-Net model on tomogram/segmentation pairs. GPU-intensive, takes hours.
@@ -34,19 +51,19 @@ STEP 2 — train OR model-explore
     Supports --submitit for SLURM job submission (njobs concurrent trials).
   IMPORTANT: For train and model-explore, ALWAYS suggest the command as a copy-pasteable block.
   NEVER call run_octopi_command for these unless the user says "run it", "go ahead", or "execute it".
-  Key params for both: --config, --voxel-size, --target-info, --tomo-alg, --output
+  Key params for both: --config, --voxel-size, --target-info (seg URI → name,user_id,session_id), --tomo-alg, --output
   Key params for model-explore: --model-type, --num-trials, --submitit, --njobs, --gpu-constraint
 
 STEP 3 — segment
   Run sliding-window inference on tomograms to produce probability maps.
   Supports model ensembling (comma-separated --model-config and --model-weights paths).
   GPU-intensive — always suggest rather than run unless the user explicitly asks.
-  Key params: --config, --model-config, --model-weights, --voxel-size, --seg-info
+  Key params: --config, --model-config, --model-weights, --tomo-uri (tomo URI), --seg-uri (seg URI)
 
 STEP 4 — localize
   Convert segmentation probability maps to 3D particle coordinates using watershed or center-of-mass.
   This is a fast command — you can run it directly.
-  Key params: --config, --seg-info, --voxel-size, --method, --pick-user-id, --pick-session-id
+  Key params: --config, --seg-uri (seg URI), --method, --pick-user-id, --pick-session-id
 
 STEP 5 (optional) — evaluate
   Measure Precision, Recall, and F1 against ground truth annotations.
@@ -56,7 +73,7 @@ STEP 5 (optional) — evaluate
 STEP 6 (optional) — membrane-extract
   Split picks by proximity to a membrane or organelle segmentation.
   Fast command — can run directly.
-  Key params: --config, --picks-info, --seg-info, --threshold, --save-session-id
+  Key params: --config, --picks-info (pick URI), --seg-info (seg URI), --threshold, --save-session-id
 
 HOW TO RESPOND
 - Use get_command_help to look up flags before suggesting a command.

--- a/octopi/mcp/server.py
+++ b/octopi/mcp/server.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from typing import Any
 
-from fastmcp import FastMCP
+try: 
+  from fastmcp import FastMCP
+except ImportError:
+  raise ImportError("MCP server is not installed. Please install it with `pip install octopi[mcp]`.")
 
 logger = logging.getLogger("octopi-mcp")
 handler = logging.StreamHandler(sys.stderr)

--- a/octopi/mcp/server.py
+++ b/octopi/mcp/server.py
@@ -1,0 +1,163 @@
+"""octopi MCP Server — exposes octopi CLI commands as MCP tools."""
+
+import logging
+import os
+import subprocess
+import sys
+from typing import Any
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger("octopi-mcp")
+handler = logging.StreamHandler(sys.stderr)
+handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+mcp = FastMCP(
+    "octopi MCP Server",
+    instructions="""octopi is a deep learning framework for automated 3D particle picking in cryo-electron tomography (cryo-ET).
+
+Always begin by asking the user what they want to do before proceeding. The typical workflow runs in this order:
+
+STEP 1 — create-targets
+  Convert pick coordinates from a CoPick project into 3D segmentation masks (Zarr).
+  This is a fast command — you can run it directly.
+  Key params: --config, --target (name or name,user_id,session_id), --voxel-size, --radius-scale
+
+STEP 2 — train OR model-explore
+  train: Train a 3D U-Net model on tomogram/segmentation pairs. GPU-intensive, takes hours.
+  model-explore: Bayesian architecture search via Optuna — recommended over train for new datasets.
+    Supports --submitit for SLURM job submission (njobs concurrent trials).
+  IMPORTANT: For train and model-explore, ALWAYS suggest the command as a copy-pasteable block.
+  NEVER call run_octopi_command for these unless the user says "run it", "go ahead", or "execute it".
+  Key params for both: --config, --voxel-size, --target-info, --tomo-alg, --output
+  Key params for model-explore: --model-type, --num-trials, --submitit, --njobs, --gpu-constraint
+
+STEP 3 — segment
+  Run sliding-window inference on tomograms to produce probability maps.
+  Supports model ensembling (comma-separated --model-config and --model-weights paths).
+  GPU-intensive — always suggest rather than run unless the user explicitly asks.
+  Key params: --config, --model-config, --model-weights, --voxel-size, --seg-info
+
+STEP 4 — localize
+  Convert segmentation probability maps to 3D particle coordinates using watershed or center-of-mass.
+  This is a fast command — you can run it directly.
+  Key params: --config, --seg-info, --voxel-size, --method, --pick-user-id, --pick-session-id
+
+STEP 5 (optional) — evaluate
+  Measure Precision, Recall, and F1 against ground truth annotations.
+  Fast command — can run directly.
+  Key params: --config, --ground-truth-user-id, --predict-user-id
+
+STEP 6 (optional) — membrane-extract
+  Split picks by proximity to a membrane or organelle segmentation.
+  Fast command — can run directly.
+  Key params: --config, --picks-info, --seg-info, --threshold, --save-session-id
+
+HOW TO RESPOND
+- Use get_command_help to look up flags before suggesting a command.
+- ALWAYS suggest long-running commands (train, model-explore, segment) as copy-pasteable code blocks.
+  NEVER run them unless the user explicitly says "run it", "go ahead and run it", or "execute it".
+- Describing what they want ("I'd like to train a model") is NOT permission to run — suggest instead.
+- For fast commands (create-targets, localize, evaluate, membrane-extract), you may run them directly
+  if the user has provided all required parameters.
+- If the user provides all required parameters, go straight to the suggestion without asking follow-up questions.
+""",
+)
+
+OCTOPI_COMMANDS = [
+    ("create-targets", "Convert pick coordinates to 3D segmentation masks (Zarr) — fast"),
+    ("train", "Train a 3D U-Net model on tomogram/segmentation pairs — GPU-intensive"),
+    ("model-explore", "Bayesian architecture search via Optuna (recommended over train) — GPU-intensive"),
+    ("segment", "Run sliding-window inference to produce probability maps — GPU-intensive"),
+    ("localize", "Convert segmentation maps to 3D particle coordinates — fast"),
+    ("evaluate", "Measure Precision/Recall/F1 against ground truth — fast"),
+    ("membrane-extract", "Split picks by membrane proximity (alias: mb-extract) — fast"),
+]
+
+LONG_RUNNING = {"train", "model-explore", "segment"}
+
+
+# ============================================================================
+# Discovery
+# ============================================================================
+
+
+@mcp.tool()
+def list_octopi_commands() -> dict[str, Any]:
+    """List all octopi commands available via this MCP server."""
+    return {
+        "success": True,
+        "commands": [{"command": f"octopi {cmd}", "description": desc} for cmd, desc in OCTOPI_COMMANDS],
+        "workflow_order": ["create-targets", "train or model-explore", "segment", "localize", "evaluate (optional)", "membrane-extract (optional)"],
+        "tip": "Call get_command_help with a command name (e.g. 'train') to see all options.",
+    }
+
+
+@mcp.tool()
+def get_command_help(command: str) -> dict[str, Any]:
+    """Get the full --help output for an octopi command.
+
+    Args:
+        command: Command name, e.g. 'train', 'segment', 'create-targets', 'model-explore'.
+    """
+    cmd = ["octopi", command, "--help"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        help_text = result.stdout or result.stderr
+        return {"success": True, "command": " ".join(cmd), "help": help_text}
+    except FileNotFoundError:
+        return {"success": False, "error": "'octopi' not found. Is octopi installed in the active environment?"}
+    except Exception as e:
+        logger.exception("get_command_help failed")
+        return {"success": False, "error": str(e)}
+
+
+# ============================================================================
+# Execution
+# ============================================================================
+
+
+@mcp.tool()
+def run_octopi_command(args: list[str], working_dir: str | None = None) -> dict[str, Any]:
+    """Run an octopi command and return its output.
+
+    Use this for fast commands: create-targets, localize, evaluate, membrane-extract.
+    For long-running GPU jobs (train, model-explore, segment), suggest the command as a
+    copy-pasteable block instead — only run them if the user explicitly asks you to.
+
+    Args:
+        args: Arguments after 'octopi', e.g. ['create-targets', '--config', 'config.json', '--voxel-size', '10'].
+        working_dir: Directory to run the command in. Defaults to cwd.
+    """
+    cwd = working_dir or os.getcwd()
+    cmd = ["octopi"] + args
+    subcommand = args[0] if args else ""
+    logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
+
+    timeout = 60 if subcommand not in LONG_RUNNING else 3600
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, timeout=timeout)
+        return {
+            "success": result.returncode == 0,
+            "command": " ".join(cmd),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "returncode": result.returncode,
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "error": f"Command timed out after {timeout}s. For GPU jobs, suggest the command for the user to run directly.",
+        }
+    except FileNotFoundError:
+        return {"success": False, "error": "'octopi' not found. Is octopi installed in the active environment?"}
+    except Exception as e:
+        logger.exception("run_octopi_command failed")
+        return {"success": False, "error": str(e)}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/octopi/mcp/server.py
+++ b/octopi/mcp/server.py
@@ -9,7 +9,7 @@ from typing import Any
 try: 
   from fastmcp import FastMCP
 except ImportError:
-  raise ImportError("MCP server is not installed. Please install it with `pip install octopi[mcp]`.")
+  raise ImportError("MCP server is not installed. Please install it with `pip install copick-mcp`.")
 
 logger = logging.getLogger("octopi-mcp")
 handler = logging.StreamHandler(sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,8 @@ dev = [
 docs = [
     "zensical==0.0.31",
 ]
-nnunet = [
-    "nnunetv2",
-    "SimpleITK"
+mcp = [
+    "copick-mcp",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "matplotlib",
     "ipywidgets",
     "rich-click",
+    "copick-mcp",
     "copick-utils",
     "multiprocess",
     "optuna-dashboard",
@@ -59,9 +60,6 @@ dev = [
 ]
 docs = [
     "zensical==0.0.31",
-]
-mcp = [
-    "copick-mcp",
 ]
 
 [project.scripts]

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,6 +24,7 @@ nav = [
         {"Create Target Labels" = "user-guide/labels.md"},
         {"Train Models" = "user-guide/training.md"},
         {"Inference" = "user-guide/inference.md"},
+        {"Claude Code / MCP" = "user-guide/claude-code-mcp.md"},
     ]},
     {"📦 API Reference" = [
         {"Overview" = "api/index.md"},


### PR DESCRIPTION
## Summary

- Adds `octopi/mcp/server.py` — a FastMCP server that exposes three MCP tools: `list_octopi_commands`, `get_command_help`, and `run_octopi_command`, with built-in guardrails to suggest (not auto-run) GPU-intensive commands
- Adds `octopi/mcp/cli.py` — an `octopi mcp` subcommand group with `install`, `status`, `uninstall`, and `start` for managing server registration in Claude Desktop, Claude Code (global), and Claude Code (project)
- Registers the MCP CLI in `octopi/main.py` behind a graceful `ImportError` guard so the base install is unaffected
- Replaces the removed `nnunet` optional dep with an `mcp` extra (`pip install octopi[mcp]`)
- Adds a user guide at `docs/user-guide/claude-code-mcp.md`