### PR TITLE
 feat: multi-resolution training, sliding-window validation, and URI-based CLI

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -69,8 +69,8 @@ Train a single 3D U-Net model:
 octopi train \
     --config experiment,config1.json \
     --config simulation,config2.json \
-    --voxel-size 10 --tomo-alg wbp \
-    --target-info targets,octopi,1
+    --tomo-uri wbp@10.0 \
+    --target-uri targets:octopi/1
 ```
 
 We can provide config files stemming from multiple copick projects. This would be relevenant in instances where you want to train a model that reflects multiple experimental acquisitions.
@@ -85,8 +85,8 @@ For optimal results, consider using Bayesian optimization to automatically disco
 octopi model-explore \
     --config experiment,config1.json \
     --config simulation,config2.json \
-    --voxel-size 10 --tomo-alg wbp \
-    --target-info targets,octopi,1
+    --tomo-uri wbp@10.0 \
+    --target-uri targets:octopi/1
 ```
 This approach automatically optimizes network architecture and hyperparameters, often achieving better performance than the default configuration. However, the exploration process can be lengthy taking up to a day to complete. 
 
@@ -99,13 +99,13 @@ Apply your trained model to new tomograms:
 ```bash
 octopi segment \
     --config config.json \
-    --seg-info predict,unet,1 \
     --model-weights results/best_model.pth \
     --model-config results/best_model_config.yaml \
-    --voxel-size 10 --tomo-alg wbp
+    --tomo-uri wbp@10.0 \
+    --seg-uri predict:unet/1
 ```
 
-This generates segmentation masks for your tomograms provided under the `--voxel-size` and `--tomo-alg` flags. The segmentation masks will be saved under the `--seg-info` flag. 
+This generates segmentation masks for your tomograms using the tomogram specified by `--tomo-uri`. The segmentation masks will be saved under the `--seg-uri` flag. 
 
 ### Step 4: Extract Particle Coordinates
 
@@ -114,7 +114,7 @@ Convert segmentation masks into precise 3D particle coordinates:
 ```bash
 octopi localize \
     --config config.json \
-    --seg-info predict,unet,1 \
+    --seg-uri predict:unet/1 \
     --pick-session-id 1 --pick-user-id unet
 ```
 

--- a/docs/user-guide/claude-code-mcp.md
+++ b/docs/user-guide/claude-code-mcp.md
@@ -151,8 +151,8 @@ Claude suggests:
 ```bash
 octopi model-explore \
     --config /data/config.json \
-    --target-info targets,octopi,1 \
-    --voxel-size 10 \
+    --tomo-uri wbp@10.0 \
+    --target-uri targets:octopi/1 \
     --model-type Unet \
     --num-trials 50 \
     --output explore_results \

--- a/docs/user-guide/inference.md
+++ b/docs/user-guide/inference.md
@@ -36,8 +36,8 @@ octopi segment \
     --config config.json \
     --model-config best_model_config.yaml \
     --model-weights best_model.pth \
-    --voxel-size 10 --tomo-alg wbp \
-    --seg-info predict,unet,1
+    --tomo-uri wbp@10.0 \
+    --seg-uri predict:unet/1
 ```
 
 ??? info "`octopi segment -h`"
@@ -47,8 +47,7 @@ octopi segment \
         | Parameter | Description | Default | Notes |
         |----------|-------------|---------|------|
         | `--config` | Path to the CoPick configuration file. | – | Required |
-        | `--voxel-size` | Voxel size (Å) of tomograms used for inference. | `10` | Must match training |
-        | `--tomo-alg` | Tomogram reconstruction algorithm used for prediction. | `wbp` | Example: `denoised` |
+        | `--tomo-uri` | Tomogram URI in the form `alg@voxel_size`. Must match training. | `wbp@10.0` | Example: `denoised@10.0` |
 
     === "Model"
 
@@ -61,7 +60,7 @@ octopi segment \
 
         | Parameter | Description | Default | Notes |
         |----------|-------------|---------|------|
-        | `--seg-info` | Output segmentation identifier (`name,user_id,session_id`). | `predict,octopi,1` | Used to organize results |
+        | `--seg-uri` | Output segmentation URI (`name:user_id/session_id`). | `predict:octopi/1` | Used to organize results |
         | `--tomo-batch-size` | Number of tomograms processed concurrently. | `1` | One per GPU worker |
         | `--run-ids` | Specific run IDs to segment. | All runs | Example: `run1,run2` |
 
@@ -74,7 +73,7 @@ octopi segment \
     --config config.json \
     --model-config model1.yaml,model2.yaml \
     --model-weights model1.pth,model2.pth \
-    --seg-info ensemble,octopi,1
+    --seg-uri ensemble:octopi/1
 ```
 
 ---
@@ -86,7 +85,7 @@ Convert segmentation masks into 3D particle coordinates using peak detection.
 ```bash
 octopi localize \
     --config config.json \
-    --seg-info predict,unet,1 \
+    --seg-uri predict:unet/1 \
     --pick-session-id 1 --pick-user-id octopi
 ```
 
@@ -100,7 +99,7 @@ The localization algorithm uses **particle size information** from your copick c
         |----------|-------------|---------|------|
         | `--config` | Path to the CoPick configuration file. | – | Required |
         | `--method` | Localization algorithm to use. | `watershed` | Options: `watershed`, `com` |
-        | `--seg-info` | Segmentation input identifier (`name,user_id,session_id`). | `predict,octopi,1` | Must match segmentation output |
+        | `--seg-uri` | Segmentation input URI (`name:user_id/session_id`). | `predict:octopi/1` | Must match segmentation output |
         | `--voxel-size` | Voxel size (Å) for localization. | `10` | Must match segmentation |
         | `--runIDs` | Specific run IDs to localize. | All runs | Example: `run1,run2` |
 

--- a/docs/user-guide/training.md
+++ b/docs/user-guide/training.md
@@ -36,9 +36,9 @@ Octopi supports two complementary workflows:
     ```bash
     octopi train \
         --config config.json \
-        --voxel-size 10 --tomo-alg wbp \
+        --tomo-uri wbp@10.0 \
         --tomo-batch-size 50 --val-interval 10 \
-        --target-info targets,octopi,1
+        --target-uri targets:octopi/1
     ```
 
     ### Fine Tuning Models
@@ -48,7 +48,7 @@ Octopi supports two complementary workflows:
     ```bash
     octopi train \
         --config config.json \
-        --voxel-size 10 --tomo-alg wbp \
+        --tomo-uri wbp@10.0 \
         --model-config results/model_config.yaml \
         --model-weights results/best_model_weights.pth
     ```
@@ -60,9 +60,8 @@ Octopi supports two complementary workflows:
             | Parameter | Description | Example |
             |----------|-------------|---------|
             | `--config` | One or more CoPick configuration files. Multiple entries may be provided as `session_name,path`. | `config.json` |
-            | `--voxel-size` | Voxel size (Å) of tomograms used for training. Must match the target segmentations. | `10` |
-            | `--target-info` | Target specification in the form `name` or `name,user_id,session_id`. | `targets,octopi,1` |
-            | `--tomo-alg` | Tomogram reconstruction algorithm(s). Multiple values may be comma-separated. | `wbp` or `denoised,wbp` |
+            | `--tomo-uri` | Tomogram URI in the form `alg@voxel_size`. Repeat the flag for multi-resolution training. | `wbp@10.0` |
+            | `--target-uri` | Target segmentation in the form `name`, `name:user_id`, or `name:user_id/session_id`. | `targets:octopi/1` |
             | `--trainRunIDs` | Explicit list of run IDs to use for training (overrides automatic splitting). | `run1,run2` |
             | `--validateRunIDs` | Explicit list of run IDs to use for validation. | `run3,run4` |
             | `--data-split` | Train/validation(/test) split. Single value → train/val, two values → train/val/test. | `0.8` or `0.7,0.1` |
@@ -134,8 +133,8 @@ Octopi supports two complementary workflows:
     ```bash
     octopi model-explore \
         --config config.json \
-        --target-info targets,octopi,1 \
-        --voxel-size 10 --tomo-alg denoised \
+        --tomo-uri denoised@10.0 \
+        --target-uri targets:octopi/1 \
         --data-split 0.7 --model-type Unet \
         --num-trials 100 --best-metric fBeta3 \
         --study-name my-explore-job
@@ -150,9 +149,8 @@ Octopi supports two complementary workflows:
             | Parameter | Description | Default | Notes |
             |----------|-------------|---------|------|
             | `--config` | One or more CoPick config paths. Multiple entries may be provided as `session_name,path`. | – | Use multiple `--config` entries to combine sessions |
-            | `--voxel-size` | Voxel size (Å) of tomograms used. | `10` | Must match target segmentations |
-            | `--target-info` | Target specification: `name` or `name,user_id,session_id`. | `targets,octopi,1` | From the label preparation step |
-            | `--tomo-alg` | Tomogram reconstruction algorithm(s). Comma-separated values enable multi-alg training. | `wbp` | Example: `denoised,wbp` |
+            | `--tomo-uri` | Tomogram URI in the form `alg@voxel_size`. Repeat the flag for multi-resolution training. | `wbp@10.0` | Example: `--tomo-uri wbp@10.0 --tomo-uri wbp@5.0` |
+            | `--target-uri` | Target segmentation: `name`, `name:user_id`, or `name:user_id/session_id`. | `targets:octopi/1` | From the label preparation step |
             | `--trainRunIDs` | Explicit list of run IDs to use for training (overrides automatic splitting). | – | Example: `run1,run2` |
             | `--validateRunIDs` | Explicit list of run IDs to use for validation. | – | Example: `run3,run4` |
             | `--data-split` | Train/val(/test) split. Single value → train/val, two values → train/val/test. | `0.8` | Example: `0.7,0.1` → 70/10/20 |

--- a/octopi/datasets/augment.py
+++ b/octopi/datasets/augment.py
@@ -5,9 +5,10 @@ from monai.transforms import (
     Orientationd, 
     RandRotate90d, 
     NormalizeIntensityd,
-    EnsureChannelFirstd, 
+    EnsureChannelFirstd,
     RandCropByPosNegLabeld,
     RandCropByLabelClassesd,
+    SpatialPadd,
     RandScaleIntensityd,
     RandShiftIntensityd,
     RandAdjustContrastd,
@@ -53,6 +54,12 @@ def get_random_transforms( input_dim, num_samples, Nclasses, bg_ratio: float = 0
         ratios = [bg_ratio] + [fg_ratio] * (Nclasses - 1)
     else:
         ratios = None  # equal sampling across all classes
+    # Pad volumes smaller than the crop up to the crop size so RandCropByLabelClassesd can always
+    # extract a full patch. This is a no-op for volumes already >= crop in every axis; it only
+    # zero-pads the short axis of thin tomograms (e.g. dataset 10006 at 20A, Z=68-92 < 96), with the
+    # label padded as background (0). Without it, thin volumes raise "ROI larger than image size".
+    pad = SpatialPadd(keys=["image", "label"], spatial_size=[input_dim[0], input_dim[1], input_dim[2]])
+
     crop = RandCropByLabelClassesd(
         keys=["image", "label"], label_key="label",
         spatial_size=[input_dim[0], input_dim[1], input_dim[2]],
@@ -69,7 +76,7 @@ def get_random_transforms( input_dim, num_samples, Nclasses, bg_ratio: float = 0
 
     return Compose([
         # Geometric augmentations
-        crop, rot,
+        pad, crop, rot,
         RandRotate90d(keys=["image", "label"], prob=0.5, spatial_axes=[1, 2], max_k=3),
         RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=0),
         RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=1),

--- a/octopi/datasets/config.py
+++ b/octopi/datasets/config.py
@@ -13,14 +13,16 @@ class DataGeneratorConfig:
     # Core data description
     config: Union[str, Dict[str, str]]
     name: str           # Name of the target for segmentation
-    voxel_size: float   # Voxel Size for training
+
+    # Tomogram URI(s) as 'alg@voxel_size'. A list (or comma string) enables
+    # multi-resolution training; the target voxel size is derived per URI.
+    tomo_uris: Union[str, List[str]] = "wbp@10.0"
 
     # Optional identifiers for the target query
     session_id: Optional[str] = None
     user_id: Optional[str] = None
 
-    # Tomogram + sampling
-    tomo_algorithm: Union[str, List[str]] = "wbp"
+    # Sampling
     ntomo_cache: int = 15
     background_ratio: float = 0.0
 
@@ -43,17 +45,6 @@ class DataGeneratorConfig:
         return cls(**filtered)
 
     # -------------------------
-    # Internal helpers
-    # -------------------------
-    def _normalize_tomo_algorithm(self) -> str:
-        """
-        Always return a comma-separated string for downstream code.
-        """
-        if isinstance(self.tomo_algorithm, list):
-            return ",".join(self.tomo_algorithm)
-        return self.tomo_algorithm
-
-    # -------------------------
     # Factory
     # -------------------------
     def create_data_generator(self, verbose: bool = True):
@@ -61,20 +52,18 @@ class DataGeneratorConfig:
         Create and initialize a Copick or MultiCopick data module.
         Safe to call inside a multiprocessing worker.
         """
-        tomo_alg = self._normalize_tomo_algorithm()
-
         if isinstance(self.config, dict):
             data_generator = generators.MultiCopickDataModule(
-                self.config, tomo_alg,
+                self.config, self.tomo_uris,
                 self.name, self.session_id, self.user_id,
-                self.voxel_size, self.ntomo_cache, self.background_ratio,
+                self.ntomo_cache, self.background_ratio,
                 verbose
             )
         else:
             data_generator = generators.CopickDataModule(
-                self.config, tomo_alg,
+                self.config, self.tomo_uris,
                 self.name, self.session_id, self.user_id,
-                self.voxel_size, self.ntomo_cache, self.background_ratio,
+                self.ntomo_cache, self.background_ratio,
                 verbose
             )
 

--- a/octopi/datasets/generators.py
+++ b/octopi/datasets/generators.py
@@ -1,21 +1,20 @@
 from monai.data import (
     DataLoader, SmartCacheDataset, CacheDataset,
-    GridPatchDataset, PatchIterd, pad_list_data_collate
 )
 from octopi.datasets import helpers as utils
 from monai.transforms import Compose
 from octopi.datasets import augment
 from octopi.datasets import io
+from typing import List
 import torch
 
 class CopickDataModule:
     def __init__(self, 
                  config: str, 
-                 tomo_alg: str,
+                 tomo_uris: List[str],
                  name: str,
                  sessionid: str = None,
                  userid: str = None,
-                 voxel_size: float = 10, 
                  tomo_batch_size: int = 15,
                  bgr: float = 0.0,
                  verbose: bool = True
@@ -29,16 +28,17 @@ class CopickDataModule:
         self.target_name = name
         self.target_session_id = sessionid
         self.target_user_id = userid
-        self.voxel_size = voxel_size
-        self.tomo_alg = tomo_alg.split(",")
-        self.tomo_batch_size = tomo_batch_size        
+        self.tomo_batch_size = tomo_batch_size
         self.bgr = bgr
         self.verbose = verbose
 
-        # Construct the Target URI
-        self.target_uri = utils.build_target_uri(name, sessionid, userid, voxel_size)
+        # Parse tomogram URIs into (alg, voxel_size) resolution pairs. Each pair
+        # is an independent training source (multi-resolution training); the
+        # target segmentation voxel size is derived from each tomogram URI.
+        self.tomo_uris = tomo_uris
+        self.resolutions = utils.parse_resolution_uris(tomo_uris)
 
-        # Initialize the input dimensions   
+        # Initialize the input dimensions
         self.nx, self.ny, self.nz = None, None, None
 
         # Available Run IDs
@@ -53,27 +53,22 @@ class CopickDataModule:
         - Only includes runs that have at least one matching segmentation.
 
         Returns:
-            available_runIDs (list): List of run IDs with available segmentations.
+            available (dict): {run_id: [(alg, voxel_size), ...]} resolutions present per run.
         """
 
-        # Get the requested tomogram algorithms
-        requested_algs = set(self.tomo_alg) if self.tomo_alg else set()
- 
-        # Scan the Runs
-        available, runs_with_seg, algs_present = utils.scan_runs(
+        # Scan the Runs for each requested (alg, voxel_size) resolution
+        available, runs_with_seg, missing = utils.scan_runs(
             root=self.root,
+            resolutions=self.resolutions,
             target_name=self.target_name,
             target_session_id=self.target_session_id,
             target_user_id=self.target_user_id,
-            voxel_size=self.voxel_size,
-            requested_algs=requested_algs,
         )
 
-        # If There are Missing Tomogram Algorithms or Segmentations, Inform the User
-        missing = requested_algs - algs_present
+        # If There are Missing Resolutions or Segmentations, Inform the User
         if runs_with_seg == 0:
             utils.missing_segmentations(self.target_name, self.target_session_id, self.target_user_id)
-        elif missing: 
+        elif missing:
             utils.missing_tomograms(missing)
 
         return available
@@ -94,10 +89,11 @@ class CopickDataModule:
             train_ratio, val_ratio, test_ratio, create_test_dataset
         )
 
-        # Get Class Info from the Training Dataset
+        # Get Class Info from the Training Dataset (classes are identical across
+        # resolutions, so read from the first requested voxel size).
         target_info = (self.target_name, self.target_session_id, self.target_user_id)
         self.Nclasses, self.class_names = utils.get_class_info(
-            self.config, self.myRunIDs['train'].keys(), target_info, self.voxel_size )
+            self.config, self.myRunIDs['train'].keys(), target_info, self.resolutions[0][1] )
 
         return self.myRunIDs
     
@@ -123,13 +119,15 @@ class CopickDataModule:
         # Define the Input Dimensions
         self.input_dim = crop_size, crop_size, crop_size
 
-        # Create the list of training files
+        # Create the list of training files. One entry per (run, resolution):
+        # each (alg, voxel_size) pair is loaded at its native spacing with its
+        # own matching target, so the model trains across all resolutions.
         train_files = [
-            { 'run': run_name, 'root': self.config, 
-                'vol_uri': f'{alg}@{self.voxel_size}', 
-                'target_uri': self.target_uri }
-            for run_name, algs in self.myRunIDs['train'].items()
-            for alg in algs
+            { 'run': run_name, 'root': self.config,
+                'vol_uri': f'{alg}@{vs}',
+                'target_uri': utils.build_target_uri(self.target_name, self.target_session_id, self.target_user_id, vs) }
+            for run_name, pairs in self.myRunIDs['train'].items()
+            for (alg, vs) in pairs
         ]
 
         # Default Train Transforms for Particle Picking
@@ -173,44 +171,39 @@ class CopickDataModule:
             pin_memory=torch.cuda.is_available()
         )
 
-        # Create the list of validation files
+        # Create the list of validation files (one entry per run × resolution).
         val_files = [
-            { 'run': run_name, 'root': self.config, 
-                'vol_uri': f'{alg}@{self.voxel_size}', 
-                'target_uri': self.target_uri }
-            for run_name, algs in self.myRunIDs['validate'].items()
-            for alg in algs
+            { 'run': run_name, 'root': self.config,
+                'vol_uri': f'{alg}@{vs}',
+                'target_uri': utils.build_target_uri(self.target_name, self.target_session_id, self.target_user_id, vs) }
+            for run_name, pairs in self.myRunIDs['validate'].items()
+            for (alg, vs) in pairs
         ]
 
-        # Load full volumes, then GridPatchDataset yields one patch at a time
-        # so the DataLoader can batch val_batch_size patches per iteration.
-        # PatchIterd yields (patch_dict, coords) tuples as GridPatchDataset expects.
-        roi = max(128, crop_size)
-        base_val_ds = CacheDataset(data=val_files, transform=augment.get_transforms(), cache_rate=1.0, num_workers=4)
-        patch_iter = PatchIterd(
-            keys=["image", "label"],
-            patch_size=(roi, roi, roi),
-            mode="constant"
-        )
-        val_ds = GridPatchDataset(data=base_val_ds, patch_iter=patch_iter, with_coordinates=False)
+        # Cache the FULL validation volumes (one item per run). The trainer
+        # runs sliding_window_inference over each volume so the validation
+        # metric matches inference-time behavior (overlap + Gaussian blending)
+        # instead of scoring independent, zero-padded patches — the latter
+        # systematically underestimates F1 by splitting particles at patch
+        # boundaries. GPU memory stays bounded by the trainer's sw_batch_size
+        # (only a few ROI windows resident at once), not by the volume size.
+        val_ds = CacheDataset(data=val_files, transform=augment.get_transforms(), cache_rate=1.0, num_workers=4)
 
-        # Validation is infrequent and its per-batch tensors are large
-        # (val_batch_size patches at ~roi³). Use fewer workers, default
-        # prefetch, and NO persistent_workers so memory is reclaimed
-        # between validations — otherwise val workers hold GBs of prefetch
-        # idle for all the training epochs between val_interval runs.
+        # batch_size=1: validation is per full volume (volumes differ in shape
+        # and cannot be stacked). Throughput is governed by the trainer's
+        # sw_batch_size, not this loader. Few workers / no persistent_workers
+        # so the cache RAM is reclaimed between infrequent validations.
         val_nw = max(1, train_nw // 4)
         val_loader = DataLoader(
-            val_ds, batch_size=val_batch_size,
+            val_ds, batch_size=1,
             shuffle=False, num_workers=val_nw,
             persistent_workers=False,
-            collate_fn=pad_list_data_collate,
             pin_memory=torch.cuda.is_available()
         )
 
         # Print the data splits
         if self.verbose:
-            utils.print_splits(self.myRunIDs, train_files, val_files)        
+            utils.print_splits(self.myRunIDs, train_files, val_files)
 
         return train_loader, val_loader
 
@@ -225,11 +218,10 @@ class CopickDataModule:
 class MultiCopickDataModule:
     def __init__(self,
                  configs: dict[str, str],
-                 tomo_alg: str,
+                 tomo_uris,
                  name: str,
                  sessionid: str = None,
                  userid: str = None,
-                 voxel_size: float = 10,
                  tomo_batch_size: int = 15,
                  bgr: float = 0.0,
                  verbose: bool = True
@@ -239,6 +231,7 @@ class MultiCopickDataModule:
 
         Args:
             configs (list): List of config file paths.
+            tomo_uris: Tomogram URI(s) (``alg@voxel_size``) for multi-resolution training.
             Other arguments are inherited from TrainLoaderManager.
         """
         # Read Copick Projects
@@ -249,16 +242,15 @@ class MultiCopickDataModule:
         self.target_name = name
         self.target_session_id = sessionid
         self.target_user_id = userid
-        self.voxel_size = voxel_size
-        self.tomo_alg = tomo_alg.split(",")
         self.tomo_batch_size = tomo_batch_size
         self.bgr = bgr
         self.verbose = verbose
-        
-        # Construct the Target URI
-        self.target_uri = utils.build_target_uri(name, sessionid, userid, voxel_size)
 
-        # Initialize the input dimensions   
+        # Parse tomogram URIs into (alg, voxel_size) resolution pairs.
+        self.tomo_uris = tomo_uris
+        self.resolutions = utils.parse_resolution_uris(tomo_uris)
+
+        # Initialize the input dimensions
         self.nx, self.ny, self.nz = None, None, None
 
         # Available Run IDs
@@ -268,56 +260,54 @@ class MultiCopickDataModule:
         """
         Identify and return a list of run IDs that have segmentations available for the target.
         """
-        requested_algs = {a.strip() for a in self.tomo_alg if a.strip()}
-        all_available: dict[str, dict[str, list[str]]] = {}
+        requested = {(a, float(v)) for a, v in self.resolutions}
+        all_available: dict[str, dict[str, list[tuple[str, float]]]] = {}
 
         total_runs_with_seg = 0
-        algs_present_global: set[str] = set()
+        resolutions_present_global: set[tuple[str, float]] = set()
 
         # Track per-session diagnostics
         session_runs_with_seg: dict[str, int] = {}
-        session_algs_present: dict[str, set[str]] = {}
+        session_resolutions_present: dict[str, set[tuple[str, float]]] = {}
 
         for session_key, root in self.roots.items():
-            available, runs_with_seg, algs_present = utils.scan_runs(
+            available, runs_with_seg, missing = utils.scan_runs(
                 root=root,
+                resolutions=self.resolutions,
                 target_name=self.target_name,
                 target_session_id=self.target_session_id,
                 target_user_id=self.target_user_id,
-                voxel_size=self.voxel_size,
-                requested_algs=requested_algs,
             )
 
-            # `available` here is {run_id: [algs]} for that root
+            # `available` here is {run_id: [(alg, voxel_size), ...]} for that root
             if available:
                 all_available[session_key] = available
 
             total_runs_with_seg += runs_with_seg
-            algs_present_global |= algs_present
+            present_here = requested - missing
+            resolutions_present_global |= present_here
 
             session_runs_with_seg[session_key] = runs_with_seg
-            session_algs_present[session_key] = algs_present
+            session_resolutions_present[session_key] = present_here
 
         # 1) No segmentations anywhere => hard error
         if total_runs_with_seg == 0:
             utils.missing_segmentations(self.target_name, self.target_session_id, self.target_user_id)
 
-        # 2) Requested tomograms missing globally => warning
-        if requested_algs:
-            missing_global = requested_algs - algs_present_global
-            if missing_global:
-                utils.missing_tomograms(missing_global)
+        # 2) Requested resolutions missing globally => warning
+        missing_global = requested - resolutions_present_global
+        if missing_global:
+            utils.missing_tomograms(missing_global)
 
-            # 3) Helpful per-session warnings
-            for session_key, runs_with_seg in session_runs_with_seg.items():
-                # Only warn if that session actually had segs (otherwise it's not a tomo-alg issue)
-                if runs_with_seg > 0:
-                    missing_here = requested_algs - session_algs_present[session_key]
-                    if missing_here == requested_algs:
-                        print(
-                            f"\n[Warning] Config '{session_key}' has matching segmentations, "
-                            f"but none of the requested tomo algs are present: {sorted(requested_algs)}\n"
-                        )
+        # 3) Helpful per-session warnings
+        for session_key, runs_with_seg in session_runs_with_seg.items():
+            # Only warn if that session actually had segs (otherwise it's not a resolution issue)
+            if runs_with_seg > 0 and not session_resolutions_present[session_key]:
+                pretty = ", ".join(f"{a}@{v}" for a, v in sorted(requested))
+                print(
+                    f"\n[Warning] Config '{session_key}' has matching segmentations, "
+                    f"but none of the requested resolutions are present: {pretty}\n"
+                )
 
         return all_available
 
@@ -373,9 +363,10 @@ class MultiCopickDataModule:
         first_session = next(iter(self.config.keys()))
         config_path = self.config[first_session]
 
-        # Get Class Info from the Training Dataset
+        # Get Class Info from the Training Dataset (classes identical across
+        # resolutions, so read from the first requested voxel size).
         self.Nclasses, self.class_names = utils.get_class_info(
-            config_path, self.myRunIDs['train'][first_session].keys(), target_info, self.voxel_size )
+            config_path, self.myRunIDs['train'][first_session].keys(), target_info, self.resolutions[0][1] )
 
         return self.myRunIDs
 
@@ -392,15 +383,15 @@ class MultiCopickDataModule:
         # Define the Input Dimensions
         self.input_dim = crop_size, crop_size, crop_size
 
-        # Create the list of training files
+        # Create the list of training files (one entry per session × run × resolution).
         train_files = [
-            { 'run': run_id, 
-               "root": self.config[session_key], 
-              'vol_uri': f'{alg}@{self.voxel_size}', 
-              'target_uri': self.target_uri }
+            { 'run': run_id,
+               "root": self.config[session_key],
+              'vol_uri': f'{alg}@{vs}',
+              'target_uri': utils.build_target_uri(self.target_name, self.target_session_id, self.target_user_id, vs) }
             for session_key, runmap in self.myRunIDs["train"].items()
-            for run_id, algs in runmap.items()
-            for alg in algs
+            for run_id, pairs in runmap.items()
+            for (alg, vs) in pairs
         ]
 
         # Default Train Transforms for Particle Picking
@@ -437,40 +428,35 @@ class MultiCopickDataModule:
             pin_memory=torch.cuda.is_available()
         )
 
-        # Create the list of validation files
+        # Create the list of validation files (one entry per session × run × resolution).
         val_files = [
-            { 'run': run_id, 
-              'root': self.config[session_key], 
-              'vol_uri': f'{alg}@{self.voxel_size}', 
-              'target_uri': self.target_uri }
+            { 'run': run_id,
+              'root': self.config[session_key],
+              'vol_uri': f'{alg}@{vs}',
+              'target_uri': utils.build_target_uri(self.target_name, self.target_session_id, self.target_user_id, vs) }
             for session_key, runmap in self.myRunIDs["validate"].items()
-            for run_id, algs in runmap.items()
-            for alg in algs                
+            for run_id, pairs in runmap.items()
+            for (alg, vs) in pairs
         ]
 
-        # Load full volumes, then GridPatchDataset yields one patch at a time
-        # so the DataLoader can batch val_batch_size patches per iteration.
-        # PatchIterd yields (patch_dict, coords) tuples as GridPatchDataset expects.
-        roi = max(128, crop_size)
-        base_val_ds = CacheDataset(data=val_files, transform=augment.get_transforms(), cache_rate=1.0, num_workers=4)
-        patch_iter = PatchIterd(
-            keys=["image", "label"],
-            patch_size=(roi, roi, roi),
-            mode="constant"
-        )
-        val_ds = GridPatchDataset(data=base_val_ds, patch_iter=patch_iter, with_coordinates=False)
+        # Cache the FULL validation volumes (one item per run). The trainer
+        # runs sliding_window_inference over each volume so the validation
+        # metric matches inference-time behavior (overlap + Gaussian blending)
+        # instead of scoring independent, zero-padded patches — the latter
+        # systematically underestimates F1 by splitting particles at patch
+        # boundaries. GPU memory stays bounded by the trainer's sw_batch_size
+        # (only a few ROI windows resident at once), not by the volume size.
+        val_ds = CacheDataset(data=val_files, transform=augment.get_transforms(), cache_rate=1.0, num_workers=4)
 
-        # Validation is infrequent and its per-batch tensors are large
-        # (val_batch_size patches at ~roi³). Use fewer workers, default
-        # prefetch, and NO persistent_workers so memory is reclaimed
-        # between validations — otherwise val workers hold GBs of prefetch
-        # idle for all the training epochs between val_interval runs.
+        # batch_size=1: validation is per full volume (volumes differ in shape
+        # and cannot be stacked). Throughput is governed by the trainer's
+        # sw_batch_size, not this loader. Few workers / no persistent_workers
+        # so the cache RAM is reclaimed between infrequent validations.
         val_nw = max(1, train_nw // 4)
         val_loader = DataLoader(
-            val_ds, batch_size=val_batch_size,
+            val_ds, batch_size=1,
             shuffle=False, num_workers=val_nw,
             persistent_workers=False,
-            collate_fn=pad_list_data_collate,
             pin_memory=torch.cuda.is_available()
         )
 

--- a/octopi/datasets/generators.py
+++ b/octopi/datasets/generators.py
@@ -140,13 +140,20 @@ class CopickDataModule:
         # Use SmartCacheDataset if the number of training files exceeds the tomo_batch_size
         if len(train_files) > self.tomo_batch_size:
             self.train_ds = SmartCacheDataset(
-                data=train_files,                
+                data=train_files,
                 transform=train_transforms,
-                cache_num=self.tomo_batch_size,  
-                replace_rate=0.15,               
+                cache_num=self.tomo_batch_size,
+                replace_rate=0.15,
                 num_init_workers=8,
                 num_replace_workers=8,
-                shuffle=False,
+                # shuffle=True so the cached window is a random mix of datasets rather than a
+                # contiguous dataset-grouped sweep (train_files is grouped by run/dataset). With
+                # shuffle=False the cache window slides through one acquisition at a time, the model
+                # over-fits each in turn and partially forgets the rest -> a periodic sawtooth in
+                # loss/val metrics (period ~= n_train_files / (replace_rate*cache_num)). The
+                # DataLoader's shuffle only reorders WITHIN the small cached window, not which
+                # tomograms are cached, so it does not substitute for this.
+                shuffle=True,
             )
         else:
             self.train_ds = CacheDataset(
@@ -401,15 +408,17 @@ class MultiCopickDataModule:
                 augment.get_random_transforms(self.input_dim, num_samples, self.Nclasses, self.bgr)
             ])
 
-        # Create the SmartCacheDataset
+        # Create the SmartCacheDataset.
+        # shuffle=True so the cached window is a random mix of datasets, not a contiguous
+        # dataset-grouped sweep (see the note in CopickDataModule.create).
         self.train_ds = SmartCacheDataset(
-            data=train_files,                
+            data=train_files,
             transform=train_transforms,
-            cache_num=self.tomo_batch_size,  
-            replace_rate=0.15,               
+            cache_num=self.tomo_batch_size,
+            replace_rate=0.15,
             num_init_workers=8,
             num_replace_workers=8,
-            shuffle=False,
+            shuffle=True,
         )
 
         # Create the DataLoader

--- a/octopi/datasets/helpers.py
+++ b/octopi/datasets/helpers.py
@@ -2,6 +2,23 @@ from octopi.datasets import io as dio
 from collections.abc import Mapping
 from octopi.utils import io as io
 import os
+import zarr
+
+
+def _spatial_shape(obj):
+    """Best-effort (z, y, x) shape of a copick tomogram/segmentation, read lazily from its
+    zarr store (metadata only, no array load). Returns None if it can't be determined."""
+    try:
+        z = zarr.open(obj.zarr(), mode="r")
+        if hasattr(z, "shape"):            # a zarr array
+            shp = z.shape
+        elif "0" in z:                     # multiscale group: level 0 = full resolution
+            shp = z["0"].shape
+        else:
+            shp = z[next(iter(z.array_keys()))].shape
+        return tuple(int(x) for x in shp[-3:])
+    except Exception:
+        return None
 
 def auto_num_workers(cap: int = 16, min_workers: int = 1) -> int:
     """
@@ -88,6 +105,7 @@ def scan_runs(
     available: dict[str, list[tuple[str, float]]] = {}
     runs_with_seg = 0
     found: set[tuple[str, float]] = set()
+    shape_skipped: list[str] = []
 
     requested = {(a, float(v)) for a, v in resolutions}
 
@@ -99,6 +117,8 @@ def scan_runs(
         # while still iterating `resolutions` in input order for determinism.
         has_seg_at: dict[float, bool] = {}
         algs_at: dict[float, set[str]] = {}
+        seg_shape_at: dict[float, tuple] = {}
+        tomo_by_alg_at: dict[float, dict] = {}
 
         for alg, vs in resolutions:
             vs = float(vs)
@@ -111,14 +131,25 @@ def scan_runs(
                 )
                 has_seg_at[vs] = len(seg) > 0
                 if has_seg_at[vs]:
+                    seg_shape_at[vs] = _spatial_shape(seg[0])
                     vs_obj = run.get_voxel_spacing(vs)
-                    algs_at[vs] = {t.tomo_type for t in vs_obj.tomograms} if vs_obj is not None else set()
+                    toms = vs_obj.tomograms if vs_obj is not None else []
+                    algs_at[vs] = {t.tomo_type for t in toms}
+                    tomo_by_alg_at[vs] = {t.tomo_type: t for t in toms}
                 else:
                     algs_at[vs] = set()
 
             if has_seg_at[vs]:
                 had_seg = True
                 if alg in algs_at[vs]:
+                    # Skip (run, alg) pairs whose tomogram shape disagrees with the target
+                    # segmentation shape at this voxel size -- they cannot be cropped together
+                    # (mirrors the old prep-multiscale lazy shape check).
+                    seg_shp = seg_shape_at.get(vs)
+                    tomo_shp = _spatial_shape(tomo_by_alg_at[vs].get(alg))
+                    if seg_shp is not None and tomo_shp is not None and seg_shp != tomo_shp:
+                        shape_skipped.append(f"{run.name} {alg}@{vs}: tomo {tomo_shp} != seg {seg_shp}")
+                        continue
                     run_pairs.append((alg, vs))
                     found.add((alg, vs))
 
@@ -126,6 +157,12 @@ def scan_runs(
             runs_with_seg += 1
         if run_pairs:
             available[run.name] = run_pairs
+
+    if shape_skipped:
+        print(
+            "\n[Warning] Skipped tomogram/target pairs with mismatched shapes "
+            f"({len(shape_skipped)}):\n\t\t" + "\n\t\t".join(shape_skipped) + "\n"
+        )
 
     missing = requested - found
     return available, runs_with_seg, missing

--- a/octopi/datasets/helpers.py
+++ b/octopi/datasets/helpers.py
@@ -22,47 +22,113 @@ def auto_num_workers(cap: int = 16, min_workers: int = 1) -> int:
         n = 4 # default to small number on non-slurm platforms
     return max(min_workers, min(cap, n))
 
+def parse_resolution_uris(tomo_uris) -> list[tuple[str, float]]:
+    """
+    Parse tomogram URIs of the form ``alg@voxel_size`` into ``(alg, voxel_size)``
+    resolution pairs for multi-resolution training.
+
+    Accepts a single string, a comma-separated string, or a list/tuple of either,
+    e.g. ``"wbp@10.0"``, ``"wbp@10.0,wbp@5.0"``, or ``["wbp@10.0", "wbp@5.0"]``.
+    Duplicate pairs are removed while preserving first-seen order.
+    """
+    if isinstance(tomo_uris, str):
+        items = [tomo_uris]
+    else:
+        items = list(tomo_uris)
+
+    resolutions: list[tuple[str, float]] = []
+    seen: set[tuple[str, float]] = set()
+    for item in items:
+        for part in str(item).split(','):
+            part = part.strip()
+            if not part:
+                continue
+            if '@' not in part:
+                raise ValueError(
+                    f"Invalid tomogram URI '{part}': expected 'alg@voxel_size' (e.g. 'wbp@10.0')."
+                )
+            alg, vs = part.rsplit('@', 1)
+            alg = alg.strip()
+            try:
+                vs = float(vs)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid voxel size in tomogram URI '{part}': '{vs}' is not a number."
+                )
+            key = (alg, vs)
+            if key not in seen:
+                seen.add(key)
+                resolutions.append(key)
+
+    if not resolutions:
+        raise ValueError("No valid tomogram URIs provided (expected 'alg@voxel_size').")
+    return resolutions
+
 def scan_runs(
     *,
     root,
-    voxel_size: float,
+    resolutions: list[tuple[str, float]],
     target_name: str,
     target_session_id: str | None,
     target_user_id: str | None,
-    requested_algs: set[str],
-) -> tuple[dict[str, list[str]], int, set[str]]:
+) -> tuple[dict[str, list[tuple[str, float]]], int, set[tuple[str, float]]]:
     """
-    Scan a single CoPick root and return:
-      - available: {run_id: [matched_algs]}
-      - runs_with_seg: number of runs that had matching segmentation
-      - algs_present: union of matched algs across available runs (for warnings)
+    Scan a single CoPick root for the requested (alg, voxel_size) resolutions and
+    return only those where BOTH a matching target segmentation and the tomogram
+    algorithm exist at that voxel size.
+
+    Args:
+        resolutions: list of (alg, voxel_size) pairs to look for.
+
+    Returns:
+      - available: {run_id: [(alg, voxel_size), ...]} resolutions present for that run
+      - runs_with_seg: number of runs with >=1 matching segmentation (at any requested vs)
+      - missing: set of (alg, voxel_size) pairs requested but never found anywhere
     """
-    available: dict[str, list[str]] = {}
+    available: dict[str, list[tuple[str, float]]] = {}
     runs_with_seg = 0
+    found: set[tuple[str, float]] = set()
 
-    runIDs = [run.name for run in root.runs]
-    for runID in runIDs:
-        run = root.get_run(runID)
+    requested = {(a, float(v)) for a, v in resolutions}
 
-        seg = run.get_segmentations(
-            name=target_name,
-            session_id=target_session_id,
-            user_id=target_user_id,
-            voxel_size=float(voxel_size),
-        )
-        if len(seg) == 0:
-            continue
-        runs_with_seg += 1
+    for run in root.runs:
+        run_pairs: list[tuple[str, float]] = []
+        had_seg = False
 
-        tomos = run.get_voxel_spacing(voxel_size).tomograms
-        run_algs = {t.tomo_type for t in tomos}
+        # Cache per-voxel-size lookups so each (run, vs) is queried only once,
+        # while still iterating `resolutions` in input order for determinism.
+        has_seg_at: dict[float, bool] = {}
+        algs_at: dict[float, set[str]] = {}
 
-        matched = sorted(requested_algs & run_algs) if requested_algs else sorted(run_algs)
-        if matched:
-            available[runID] = matched
+        for alg, vs in resolutions:
+            vs = float(vs)
+            if vs not in has_seg_at:
+                seg = run.get_segmentations(
+                    name=target_name,
+                    session_id=target_session_id,
+                    user_id=target_user_id,
+                    voxel_size=vs,
+                )
+                has_seg_at[vs] = len(seg) > 0
+                if has_seg_at[vs]:
+                    vs_obj = run.get_voxel_spacing(vs)
+                    algs_at[vs] = {t.tomo_type for t in vs_obj.tomograms} if vs_obj is not None else set()
+                else:
+                    algs_at[vs] = set()
 
-    algs_present = set().union(*available.values()) if available else set()
-    return available, runs_with_seg, algs_present
+            if has_seg_at[vs]:
+                had_seg = True
+                if alg in algs_at[vs]:
+                    run_pairs.append((alg, vs))
+                    found.add((alg, vs))
+
+        if had_seg:
+            runs_with_seg += 1
+        if run_pairs:
+            available[run.name] = run_pairs
+
+    missing = requested - found
+    return available, runs_with_seg, missing
 
 def missing_segmentations(target_name, target_session_id, target_user_id):
     raise RuntimeError(
@@ -72,11 +138,16 @@ def missing_segmentations(target_name, target_session_id, target_user_id):
         f"Please check the target name, user ID, and session ID.\n"
     )
 
-def missing_tomograms(algorithms):
+def missing_tomograms(missing):
+    """
+    Warn about requested resolutions that were never found. ``missing`` is a set
+    of (alg, voxel_size) pairs.
+    """
+    pretty = ", ".join(f"{a}@{v}" for a, v in sorted(missing)) if missing else ""
     print(
-        f"\n[Warning] The following tomogram algorithms are not present in the Copick Project:\n"
-        f"\t\t{algorithms}\n"
-        f"These tomogram algorithms will be ignored.\n"
+        f"\n[Warning] The following tomogram/target resolutions are not present in the Copick Project:\n"
+        f"\t\t{pretty}\n"
+        f"These resolutions will be ignored.\n"
     )
 
 def get_data_splits(
@@ -232,11 +303,23 @@ def get_parameters(datamodule):
     this is a single-config or multi-config datamodule.
     """
 
+    # Multi-resolution: a list of (alg, voxel_size) pairs. Record the full set
+    # of training URIs plus representative scalars (first resolution) for any
+    # downstream consumer that still expects a single voxel_size / algorithm.
+    resolutions = datamodule.resolutions
+    tomo_uris = [f"{alg}@{vs}" for alg, vs in resolutions]
+    unique_vss = sorted({vs for _, vs in resolutions})
+
     base = {
-        "target_uri": build_target_uri(datamodule.target_name, datamodule.target_session_id, datamodule.target_user_id, datamodule.voxel_size),
         "target_info": [datamodule.target_user_id, datamodule.target_session_id, datamodule.target_name],
-        "voxel_size": datamodule.voxel_size,
-        "tomo_algorithm": datamodule.tomo_alg,
+        "tomo_uris": tomo_uris,
+        "target_uris": [
+            build_target_uri(datamodule.target_name, datamodule.target_session_id, datamodule.target_user_id, vs)
+            for vs in unique_vss
+        ],
+        # Representative scalars (first resolution) for backward compatibility.
+        "voxel_size": resolutions[0][1],
+        "tomo_algorithm": sorted({alg for alg, _ in resolutions}),
         "background_ratio": datamodule.bgr,
     }
 

--- a/octopi/entry_points/common.py
+++ b/octopi/entry_points/common.py
@@ -65,8 +65,11 @@ def train_parameters(octopi: bool = False):
 def config_parameters(single_config: bool):
     """Decorator for adding config parameters"""
     def decorator(f):
-        f = click.option("-vs", "--voxel-size", type=float, default=10,
-                        help="Voxel size of tomograms used")(f)
+        f = click.option("-uri", "--tomo-uri", "tomo_uris", type=str, multiple=True,
+                        default=("wbp@10.0",),
+                        help="Tomogram URI(s) as 'alg@voxel_size'. Repeat the flag for "
+                             "multi-resolution training, e.g. --tomo-uri wbp@10.0 --tomo-uri wbp@5.0. "
+                             "The target segmentation voxel size is derived from each URI.")(f)
         if single_config:
             f = click.option("-c", "--config", type=click.Path(exists=True), required=True,
                             help="Path to the configuration file")(f)
@@ -82,11 +85,9 @@ def inference_parameters():
         f = click.option('-runs', "--run-ids", type=str, default=None,
                         callback=lambda ctx, param, value: parsers.parse_list(value) if value else None,
                         help="List of run IDs for prediction, e.g., run1,run2 or [run1,run2]. If not provided, all available runs will be processed.")(f)
-        f = click.option('-seginfo', "--seg-info", type=str, default='predict,octopi,1',
+        f = click.option('-suri', "--seg-uri", type=str, default='predict:octopi/1',
                         callback=lambda ctx, param, value: parsers.parse_target(value) if value else value,
-                        help='Information Query to save Segmentation predictions under (e.g., "name" or "name,user_id,session_id" - Default UserID is octopi and SessionID is 1')(f)
-        f = click.option('-alg', "--tomo-alg", type=str, default='wbp',
-                        help="Tomogram algorithm used for produces segmentation prediction masks")(f)
+                        help='Information Query to save Segmentation predictions under (e.g., "name" or "name:user_id/session_id"')(f)
         f = click.option('-swbs', "--sliding-window-batch-size", default=4, type=IntRange(min=1),
                         help="Batch size for sliding window inference")(f)
         f = click.option('--overlap', '-o', default=0.5, type=FloatRange(0.0, 1.0),

--- a/octopi/entry_points/groups.py
+++ b/octopi/entry_points/groups.py
@@ -32,7 +32,7 @@ click.rich_click.OPTION_GROUPS = {
     "routines train": [
         {
             "name": "Input/Output Arguments",
-            "options": ["--config", "--voxel-size", "--target-info", "--tomo-alg", 
+            "options": ["--config", "--tomo-uri", "--target-uri",
                        "--trainRunIDs", "--validateRunIDs", "--data-split", "--output"]
         },
         {
@@ -67,7 +67,7 @@ click.rich_click.OPTION_GROUPS = {
     "routines segment": [
         {
             "name": "Input Arguments",
-            "options": ["--config", "--voxel-size", "--tomo-alg", "--run-ids"]
+            "options": ["--config", "--tomo-uri", "--run-ids"]
         },
         {
             "name": "Model Arguments",
@@ -75,13 +75,13 @@ click.rich_click.OPTION_GROUPS = {
         },
         {
             "name": "Inference Arguments",
-            "options": ["--seg-info", "--sliding-window-batch-size", "--overlap", "--ntta"]
+            "options": ["--seg-uri", "--sliding-window-batch-size", "--overlap", "--ntta"]
         }
     ],
     "routines localize": [
         {
             "name": "Input Arguments",
-            "options": ["--config", "--method", "--seg-info", "--voxel-size", "--runIDs"]
+            "options": ["--config", "--method", "--seg-uri", "--voxel-size", "--runIDs"]
         },
         {
             "name": "Localize Arguments",
@@ -96,7 +96,7 @@ click.rich_click.OPTION_GROUPS = {
     "routines model-explore": [
         {
             "name": "Input/Output Arguments",
-            "options": ["--config", "--voxel-size", "--target-info", "--tomo-alg", 
+            "options": ["--config", "--tomo-uri", "--target-uri",
                        "--trainRunIDs", "--validateRunIDs", "--data-split", "--output",  "--study-name",]
         },
         {
@@ -128,8 +128,8 @@ click.rich_click.OPTION_GROUPS = {
     "routines membrane-extract": [
         {
             "name": "Input Arguments",
-            "options": ["--config", "--voxel-size", "--picks-info", 
-                        "--seg-info", "--runIDs"]
+            "options": ["--config", "--voxel-size", "--picks-uri",
+                        "--seg-uri", "--runIDs"]
         },
         {
             "name": "Parameters",
@@ -152,49 +152,6 @@ click.rich_click.OPTION_GROUPS = {
         {
             "name": "Voxel Settings",
             "options": ["--input-voxel-size", "--output-voxel-size"]
-        }
-    ],
-    "routines nnunet prepare": [
-        {
-            "name": "Input Arguments",
-            "options": ["--config", "--voxel-size", "--tomo-alg", "--seg-info",
-                        "--train-run-ids", "--test-run-ids"]
-        },
-        {
-            "name": "Output Arguments",
-            "options": ["--dataset-id", "--dataset-name", "--raw"]
-        },
-        {
-            "name": "Parameters",
-            "options": ["--num-workers"]
-        }
-    ],
-    "routines nnunet train": [
-        {
-            "name": "Input/Output Arguments",
-            "options": ["--dataset-id", "--dataset-name", "--raw", "--preprocessed", "--results"]
-        },
-        {
-            "name": "Training Arguments",
-            "options": ["--configuration", "--folds", "--model", "--num-gpus"]
-        },
-        {
-            "name": "Options",
-            "options": ["--skip-preprocess"]
-        }
-    ],
-    "routines nnunet segment": [
-        {
-            "name": "Input Arguments",
-            "options": ["--config", "--tomo-uri", "--run-ids"]
-        },
-        {
-            "name": "Model Arguments",
-            "options": ["--plans", "--dataset", "--weights"]
-        },
-        {
-            "name": "Inference Arguments",
-            "options": ["--seg-uri", "--tta"]
         }
     ],
 }

--- a/octopi/entry_points/run_extract_mb_picks.py
+++ b/octopi/entry_points/run_extract_mb_picks.py
@@ -77,17 +77,17 @@ def save_parameters( params_dict: dict, output_path: str ):
 @click.option('-rids','--runIDs', type=str, default=None,
               callback=lambda ctx, param, value: parsers.parse_list(value) if value else None,
               help="List of run IDs to process")
-@click.option('-si','--seg-info', type=str, default=None,
+@click.option('-suri','--seg-uri', type=str, default=None,
               callback=lambda ctx, param, value: parsers.parse_target(value) if value else None,
-              help='Query for the membrane segmentation (e.g., "name" or "name,user_id,session_id")')
-@click.option('-pi','--picks-info', type=str, required=True,
+              help='Query for the membrane segmentation as "name", "name:user_id", or "name:user_id/session_id".')
+@click.option('-puri','--picks-uri', type=str, required=True,
               callback=lambda ctx, param, value: parsers.parse_target(value),
-              help='Query for the picks (e.g., "name" or "name,user_id,session_id")')
+              help='Query for the picks as "name", "name:user_id", or "name:user_id/session_id".')
 @click.option('-vs', '--voxel-size', type=float, default=10,
               help="Voxel size")
 @click.option('-c', '--config', type=click.Path(exists=True), required=True,
               help="Path to the configuration file")
-def cli(config, voxel_size, picks_info, seg_info, runids,
+def cli(config, voxel_size, picks_uri, seg_uri, runids,
         threshold, n_procs,
         save_user_id, save_session_id):
     """
@@ -117,15 +117,15 @@ def cli(config, voxel_size, picks_info, seg_info, runids,
 
     # Extract membrane-bound picks with default distance threshold (1–10 voxels)
     octopi membrane-extract -c config.json \\
-        --picks-info predictions,octopi,1 \\
-        --seg-info membrane,membrain-seg,1 \\
+        --picks-uri predictions:octopi/1 \\
+        --seg-uri membrane:membrain-seg/1 \\
         --save-user-id octopi \\
         --save-session-id 1
 
     # Use a custom distance range (2–6 voxels)
     octopi membrane-extract -c config.json \\
-        --picks-info predictions,octopi,1 \\
-        --seg-info membrane,membrain-seg,1 \\
+        --picks-uri predictions:octopi/1 \\
+        --seg-uri membrane:membrain-seg/1 \\
         --threshold 2,6 \\
         --save-user-id octopi \\
         --save-session-id 3
@@ -133,7 +133,7 @@ def cli(config, voxel_size, picks_info, seg_info, runids,
 
     run_mb_extract(
         config, voxel_size,
-        picks_info, seg_info,
+        picks_uri, seg_uri,
         runids, threshold, n_procs,
         save_user_id, save_session_id
     )

--- a/octopi/entry_points/run_localize.py
+++ b/octopi/entry_points/run_localize.py
@@ -93,32 +93,32 @@ def save_parameters(seg_info: Tuple[str, str, str],
               help="List of runIDs to run inference on, e.g., run1,run2,run3 or [run1,run2,run3]")
 @click.option('-vs', '--voxel-size', type=float, default=10,
               help="Voxel size for localization")
-@click.option('-sinfo', '--seg-info', type=str, default='predict,octopi,1',
+@click.option('-suri', '--seg-uri', type=str, default='predict:octopi/1',
               callback=lambda ctx, param, value: parsers.parse_target(value),
-              help='Query for the organelles segmentations (e.g., "name" or "name,user_id,session_id")')
+              help='Query for the organelle segmentations as "name", "name:user_id", or "name:user_id/session_id".')
 @click.option('-m', '--method', type=click.Choice(['watershed', 'com'], case_sensitive=False), 
               default='watershed',
               help="Localization method to use")
 @click.option('-c', '--config', type=click.Path(exists=True), required=True,
               help="Path to the CoPick configuration file")
-def cli(config, method, seg_info, voxel_size, runids,
+def cli(config, method, seg_uri, voxel_size, runids,
         radius_min_scale, radius_max_scale, filter_size, pick_objects, n_procs,
         pick_session_id, pick_user_id):
     """
-    Convert Segmentation Masks to 3D Particle Coordinates. 
+    Convert Segmentation Masks to 3D Particle Coordinates.
 
-    This command converts segmentation masks into 3D particle coordinates using size-based filtering. 
-    It supports two localization methods: watershed and center of mass. The resulting particle coordinates 
+    This command converts segmentation masks into 3D particle coordinates using size-based filtering.
+    It supports two localization methods: watershed and center of mass. The resulting particle coordinates
     in your copick project, organized by segmentation name, user ID, and session ID for easy tracking and comparison.
-    
+
     \b
     Examples:
       # Localize particles with default settings
-      octopi localize -c config.json --seg-info predict,octopi,1
+      octopi localize -c config.json --seg-uri predict:octopi/1
     """
 
     print('\n🚀 Localizing Segmentation Masks into 3D Coordinates...\n')
-    run_localize(config, method, seg_info, voxel_size, runids,
+    run_localize(config, method, seg_uri, voxel_size, runids,
         radius_min_scale, radius_max_scale, filter_size, pick_objects, n_procs,
         pick_session_id, pick_user_id)
     

--- a/octopi/entry_points/run_optuna.py
+++ b/octopi/entry_points/run_optuna.py
@@ -22,11 +22,9 @@ import rich_click as click
               help="List of training run IDs, e.g., run1,run2 or [run1,run2]")
 @click.option('-n', '--study-name', type=str, default="model-search",
               help="Name of the Optuna/MLflow experiment")
-@click.option('-alg', '--tomo-alg', type=str, default='wbp',
-              help="Tomogram algorithm used for training, provide a comma-separated list of algorithms for multiple options. (e.g., 'denoised,wbp')")
-@click.option('-tinfo', '--target-info', type=str, default="targets,octopi,1",
+@click.option('-turi', '--target-uri', type=str, default="targets:octopi/1",
               callback=lambda ctx, param, value: parsers.parse_target(value),
-              help="Target information, e.g., 'name' or 'name,user_id,session_id'")
+              help="Target query as 'name', 'name:user_id', or 'name:user_id/session_id'. Default 'targets:octopi/1'.")
 @click.option('-o', '--output', type=str, default='explore_results',
               help="Name of the output directory")
 
@@ -43,7 +41,7 @@ import rich_click as click
               help="SLURM job timeout per trial when using submitit (hours)")
 @common.config_parameters(single_config=False)
 def cli(
-    config, voxel_size, target_info, tomo_alg, study_name, 
+    config, tomo_uris, target_uri, study_name,
     trainrunids, validaterunids, data_split, model_type, num_epochs, background_ratio,
     val_interval, ncache_tomos, best_metric, num_trials, random_seed, output,
     submitit, njobs, cpu_constraint, gpu_constraint, timeout):
@@ -52,14 +50,16 @@ def cli(
     """
 
     print('\n🚀 Starting a new Octopi Model Architecture Search...\n')
+    # click `multiple=True` yields a tuple; normalize to a list for downstream use.
+    tomo_uris = list(tomo_uris)
     run_model_explore(
-        config, voxel_size, target_info, tomo_alg, study_name, 
+        config, tomo_uris, target_uri, study_name,
         trainrunids, validaterunids, data_split, model_type, background_ratio,
         num_epochs, val_interval, ncache_tomos, best_metric, num_trials, random_seed, output,
         submitit=submitit, njobs=njobs, cpu_constraint=cpu_constraint, gpu_constraint=gpu_constraint, timeout=timeout,
     )
 
-def run_model_explore(config, voxel_size, target_info, tomo_alg, study_name, 
+def run_model_explore(config, tomo_uris, target_info, study_name, 
         trainrunids, validaterunids, data_split, model_type, background_ratio,
         num_epochs, val_interval, ncache_tomos, best_metric, num_trials, random_seed, 
         output, submitit, njobs, cpu_constraint, gpu_constraint, timeout):
@@ -84,8 +84,7 @@ def run_model_explore(config, voxel_size, target_info, tomo_alg, study_name,
         target_name=target_info[0],
         target_user_id=target_info[1],
         target_session_id=target_info[2],
-        tomo_algorithm=tomo_alg,
-        voxel_size=voxel_size,
+        tomo_uris=tomo_uris,
         model_type=model_type,
         random_seed=random_seed,
         num_epochs=num_epochs,

--- a/octopi/entry_points/run_segment.py
+++ b/octopi/entry_points/run_segment.py
@@ -61,12 +61,16 @@ def inference(
 # Model Arguments
 @common.inference_model_parameters()
 # Input Arguments
-@common.config_parameters(single_config=True)
-def cli(config, voxel_size,
-        model_config, model_weights,
-        tomo_alg, seg_info, run_ids,
-        sliding_window_batch_size, overlap, ntta
-        ):
+@click.option(
+    "-c", "--config", type=click.Path(exists=True), required=True,
+    help="Path to copick configuration file" )
+@click.option(
+    "-uri", "--tomo-uri", type=str, required=False, default='wbp@10.0',
+    help="Tomogram URI for Inference (tomo-alg@voxel-size)" 
+)
+def cli(config, tomo_uri,
+        model_config, model_weights, seg_uri, run_ids,
+        sliding_window_batch_size, overlap, ntta):
     """
     Segment volumes using trained neural network models.
     
@@ -81,29 +85,37 @@ def cli(config, voxel_size,
     Examples:
       # Segment with a single model
       octopi segment -c config.json \\
+        --tomo-uri wbp@10.0 \\
         --model-config model.yaml --model-weights model.pth \\
-        --seg-info predictions,octopi,1
-    
+        --seg-uri predictions:octopi/1
+
     \b
       # Segment with model ensemble (comma-separated)
       octopi segment -c config.json \\
+        --tomo-uri wbp@10.0 \\
         --model-config model1.yaml,model2.yaml \\
         --model-weights model1.pth,model2.pth \\
-        --seg-info ensemble,octopi,1
+        --seg-uri ensemble:octopi/1
     
     \b
       # Segment specific runs only
       octopi segment -c config.json \\
+        --tomo-uri wbp@10.0 \\
         --model-config model.yaml --model-weights model.pth \\
         --run-ids TS_001,TS_002,TS_003
     """
     
     # Set default values if not provided
-    seg_info = list(seg_info)  # Convert tuple to list
+    seg_info = list(seg_uri)  # Convert parsed (name, user, session) tuple to list
     if seg_info[1] is None:
         seg_info[1] = "octopi"
     if seg_info[2] is None:
         seg_info[2] = "1"
+
+    # Parse the tomogram URI
+    if '@' not in tomo_uri:
+        raise ValueError("Tomogram URI must contain '@' for voxel size.")
+    tomo_alg, voxel_size = tomo_uri.split('@')
 
     # Call the inference function with parsed arguments
     print('\n🚀 Starting inference with Octopi...\n')
@@ -112,7 +124,7 @@ def cli(config, voxel_size,
         model_weights=model_weights,
         model_config=model_config,
         seg_info=seg_info,
-        voxel_size=voxel_size,
+        voxel_size=float(voxel_size),
         tomo_algorithm=tomo_alg,
         run_ids=run_ids,
         swbs=sliding_window_batch_size,

--- a/octopi/entry_points/run_train.py
+++ b/octopi/entry_points/run_train.py
@@ -1,14 +1,12 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from octopi.entry_points import common
 from octopi.utils import parsers
-from octopi import cli_context
 import rich_click as click
 
 def train_model(
     copick_config_path: str,
     target_info: Tuple[str, str, str],
-    tomo_algorithm: str = 'wbp',
-    voxel_size: float = 10,
+    tomo_uris: Union[List[str], str],
     trainRunIDs: List[str] = None,
     validateRunIDs: List[str] = None,    
     model_config: str = None,
@@ -33,16 +31,14 @@ def train_model(
     matplotlib.use("Agg", force=True)
 
     from octopi.datasets.config import DataGeneratorConfig
-    from octopi.datasets import generators
     from monai.losses import TverskyLoss
-    from octopi.utils import parsers, io
     from octopi.workflows import train
 
     # Create a data generator 
     cfg = DataGeneratorConfig(
         config=copick_config_path,
         name=target_info[0], user_id=target_info[1], session_id=target_info[2],
-        voxel_size=voxel_size, tomo_algorithm=tomo_algorithm, ntomo_cache=ncache_tomos,
+        tomo_uris=tomo_uris, ntomo_cache=ncache_tomos,
         background_ratio=background_ratio, data_split=data_split,
         trainRunIDs=trainRunIDs, validateRunIDs=validateRunIDs
     )
@@ -105,34 +101,36 @@ def get_model_config(channels, strides, res_units, dim_in):
 @click.option('-truns', "--trainRunIDs", type=str, default=None,
               callback=lambda ctx, param, value: parsers.parse_list(value) if value else None,
               help="List of training run IDs, e.g., run1,run2,run3")
-@click.option('-alg',"--tomo-alg", type=str, default='wbp',
-              help="Tomogram algorithm used for training, provide a comma-separated list of algorithms for multiple options. (e.g., 'denoised,wbp')")
-@click.option('-tinfo', "--target-info", type=str, default="targets,octopi,1",
+@click.option('-turi', "--target-uri", type=str, default="targets:octopi/1",
               callback=lambda ctx, param, value: parsers.parse_target(value),
-              help="Target information, e.g., 'name' or 'name,user_id,session_id'. Default is 'targets,octopi,1'.")
+              help="Target query as 'name', 'name:user_id', or 'name:user_id/session_id'. Default 'targets:octopi/1'.")
 @common.config_parameters(single_config=False)
 def cli(
-    config, voxel_size, target_info, tomo_alg, trainrunids, validaterunids, data_split,
+    config, tomo_uris, target_uri, trainrunids, validaterunids, data_split,
     model_config, model_weights,
     channels, strides, res_units, dim_in,
-    num_epochs, val_interval, ncache_tomos, best_metric, 
+    num_epochs, val_interval, ncache_tomos, best_metric,
     batch_size, lr, tversky_alpha, background_ratio, output):
     """
     Train 3D CNN U-Net models for Cryo-ET semantic segmentation.
     """
 
     print('\n🚀 Training a New Octopi Model...\n')
-    run_train(config, voxel_size, target_info, tomo_alg, trainrunids, validaterunids, data_split,
+    # click `multiple=True` yields a tuple; normalize to a list for downstream use.
+    tomo_uris = list(tomo_uris)
+    run_train(config, tomo_uris, target_uri,  trainrunids, validaterunids, data_split,
         model_config, model_weights,
         channels, strides, res_units, dim_in,
         num_epochs, val_interval, ncache_tomos, best_metric, 
         batch_size, lr, tversky_alpha, background_ratio, output)
 
-def run_train(config, voxel_size, target_info, tomo_alg, trainrunids, validaterunids, data_split,
-        model_config, model_weights,
-        channels, strides, res_units, dim_in,
-        num_epochs, val_interval, ncache_tomos, best_metric, 
-        batch_size, lr, tversky_alpha, background_ratio, output):
+def run_train(
+    config, tomo_uris, target_info, trainrunids, validaterunids, data_split,
+    model_config, model_weights,
+    channels, strides, res_units, dim_in,
+    num_epochs, val_interval, ncache_tomos, best_metric, 
+    batch_size, lr, tversky_alpha, background_ratio, output
+    ):
     """
     Run the training model.
     """
@@ -154,8 +152,7 @@ def run_train(config, voxel_size, target_info, tomo_alg, trainrunids, validateru
     train_model(
         copick_config_path=copick_configs, 
         target_info=target_info,
-        tomo_algorithm=tomo_alg,
-        voxel_size=voxel_size,
+        tomo_uris=tomo_uris,
         model_config=model_config_dict,
         model_weights=model_weights,
         output=output,

--- a/octopi/entry_points/run_train.py
+++ b/octopi/entry_points/run_train.py
@@ -32,9 +32,10 @@ def train_model(
 
     from octopi.datasets.config import DataGeneratorConfig
     from monai.losses import TverskyLoss
+    from octopi.models import common as model_common
     from octopi.workflows import train
 
-    # Create a data generator 
+    # Create a data generator
     cfg = DataGeneratorConfig(
         config=copick_config_path,
         name=target_info[0], user_id=target_info[1], session_id=target_info[2],
@@ -45,10 +46,35 @@ def train_model(
     data_generator = cfg.create_data_generator()
     model_config['num_classes'] = data_generator.Nclasses
 
-    # Loss Functions
-    alpha = tversky_alpha
-    beta = 1 - alpha
-    loss_function = TverskyLoss(include_background=True, to_onehot_y=True, softmax=True, alpha=alpha, beta=beta)
+    # Loss Functions.
+    # If the model config records a base loss in its `optimizer:` block, rebuild that exact loss
+    # (e.g. a FocalLoss/gamma chosen by model-explore). Otherwise default to TverskyLoss(alpha).
+    opt = model_config.get('optimizer', {}) if isinstance(model_config, dict) else {}
+    cfg_loss = opt.get('loss_function')
+    if cfg_loss and cfg_loss != 'TverskyLoss' and cfg_loss != 'DeepSupervisionLoss':
+        loss_function = model_common.get_loss_function(
+            loss_name=cfg_loss,
+            gamma=opt.get('gamma'), alpha=opt.get('alpha'),
+            weight_tversky=opt.get('weight_tversky'),
+        )
+        print(f"Using loss from model config: {cfg_loss} "
+              f"(gamma={opt.get('gamma')}, alpha={opt.get('alpha')}, "
+              f"weight_tversky={opt.get('weight_tversky')})")
+    else:
+        if cfg_loss == 'DeepSupervisionLoss':
+            print(
+                "[Warning] model_config records loss_function: DeepSupervisionLoss -- a legacy "
+                "save-path artifact that lost the base loss and its gamma/alpha. The original loss "
+                "cannot be rebuilt from this config; falling back to TverskyLoss. Re-run "
+                "`octopi model-explore` to regenerate the config if you need the exact loss."
+            )
+        if cfg_loss == 'TverskyLoss' and opt.get('alpha') is not None:
+            alpha = opt['alpha']
+        else:
+            alpha = tversky_alpha
+        beta = 1 - alpha
+        loss_function = TverskyLoss(include_background=True, to_onehot_y=True, softmax=True, alpha=alpha, beta=beta)
+        print(f"Using TverskyLoss (alpha={alpha})")
 
     # Read per-class score weights from copick config metadata (score_weight key)
     import copick as _copick

--- a/octopi/mcp/server.py
+++ b/octopi/mcp/server.py
@@ -27,15 +27,17 @@ URI FORMATS
   Users express resources using short URI notation. Translate these to CLI flags as follows:
 
   Tomogram URI  "algorithm@voxel_spacing"   e.g. "wbp@10.0"
-    → --tomo-alg wbp --voxel-size 10.0
+    → --tomo-uri wbp@10.0
+    Repeat for multi-resolution training: --tomo-uri wbp@10.0 --tomo-uri wbp@5.0
 
   Segmentation URI  "name:user_id/session_id"   e.g. "predict:octopi/1"
-    → --seg-info predict,octopi,1  (comma-separated: name,user_id,session_id)
+    → --seg-uri predict:octopi/1
 
   Pick/Target URI  "name:user_id/session_id"   e.g. "ribosome:manual/1"
     → --target ribosome,manual,1  (for create-targets source picks)
-    → --picks-info ribosome,manual,1  (for membrane-extract)
+    → --picks-uri ribosome:manual/1  (for membrane-extract)
     → --pick-user-id manual --pick-session-id 1  (for localize output)
+    → --target-uri targets:octopi/1  (for train / model-explore target segmentation)
 
   Multiple URIs of the same type are passed as repeated flags, e.g.:
     --target ribosome,manual,1 --target virus-like-particle,tm,2
@@ -51,7 +53,7 @@ STEP 2 — train OR model-explore
     Supports --submitit for SLURM job submission (njobs concurrent trials).
   IMPORTANT: For train and model-explore, ALWAYS suggest the command as a copy-pasteable block.
   NEVER call run_octopi_command for these unless the user says "run it", "go ahead", or "execute it".
-  Key params for both: --config, --voxel-size, --target-info (seg URI → name,user_id,session_id), --tomo-alg, --output
+  Key params for both: --config, --tomo-uri (tomogram URI, repeatable for multi-resolution), --target-uri (target seg URI), --output
   Key params for model-explore: --model-type, --num-trials, --submitit, --njobs, --gpu-constraint
 
 STEP 3 — segment
@@ -73,7 +75,7 @@ STEP 5 (optional) — evaluate
 STEP 6 (optional) — membrane-extract
   Split picks by proximity to a membrane or organelle segmentation.
   Fast command — can run directly.
-  Key params: --config, --picks-info (pick URI), --seg-info (seg URI), --threshold, --save-session-id
+  Key params: --config, --picks-uri (pick URI), --seg-uri (seg URI), --threshold, --save-session-id
 
 HOW TO RESPOND
 - Use get_command_help to look up flags before suggesting a command.

--- a/octopi/models/common.py
+++ b/octopi/models/common.py
@@ -24,7 +24,44 @@ def get_model(architecture):
     return model
 
 
-def get_loss_function(trial, loss_name = None):
+def get_loss_function(trial=None, loss_name=None, gamma=None, alpha=None, weight_tversky=None):
+    """Build a segmentation loss.
+
+    Two modes:
+      - Optuna search: pass ``trial`` (and optionally ``loss_name``); any param not given
+        explicitly is sampled from ``trial``.
+      - Explicit/config-driven: pass ``trial=None`` with ``loss_name`` and the relevant params
+        (``gamma``/``alpha``/``weight_tversky``); nothing is sampled. Used by ``octopi train`` to
+        rebuild the exact loss recorded in a model config's ``optimizer:`` block.
+    """
+
+    def _default_when_no_trial(name, default):
+        # Config-driven mode (trial is None) but the param was omitted from the config. Fall back to
+        # a documented default rather than crashing on trial.suggest_float() with no trial.
+        print(f"[Warning] get_loss_function: '{name}' not provided and no Optuna trial to sample "
+              f"from; using default {name}={default}.")
+        return default
+
+    def _suggest_gamma(g):
+        if g is not None:
+            return g
+        if trial is None:
+            return _default_when_no_trial("gamma", 2.0)
+        return round(trial.suggest_float("gamma", 0.1, 2), 3)
+
+    def _suggest_alpha(a):
+        if a is not None:
+            return a
+        if trial is None:
+            return _default_when_no_trial("alpha", 0.5)
+        return round(trial.suggest_float("alpha", 0.1, 0.5), 3)
+
+    def _suggest_weight_tversky(w):
+        if w is not None:
+            return w
+        if trial is None:
+            return _default_when_no_trial("weight_tversky", 0.5)
+        return round(trial.suggest_float("weight_tversky", 0.1, 0.9), 3)
 
     # Loss function selection
     if loss_name is None:
@@ -33,19 +70,19 @@ def get_loss_function(trial, loss_name = None):
             ["FocalLoss", "WeightedFocalTverskyLoss", 'FocalTverskyLoss'])
 
     if loss_name == "FocalLoss":
-        gamma = round(trial.suggest_float("gamma", 0.1, 2), 3)
+        gamma = _suggest_gamma(gamma)
         loss_function = FocalLoss(include_background=True, to_onehot_y=True, use_softmax=True, gamma=gamma)
 
     elif loss_name == "TverskyLoss":
-        alpha = round(trial.suggest_float("alpha", 0.1, 0.5), 3)
+        alpha = _suggest_alpha(alpha)
         beta = 1.0 - alpha
         loss_function = TverskyLoss(include_background=True, to_onehot_y=True, softmax=True, alpha=alpha, beta=beta)
 
     elif loss_name == 'WeightedFocalTverskyLoss':
-        gamma = round(trial.suggest_float("gamma", 0.1, 2), 3)
-        alpha = round(trial.suggest_float("alpha", 0.1, 0.5), 3)
+        gamma = _suggest_gamma(gamma)
+        alpha = _suggest_alpha(alpha)
         beta = 1.0 - alpha
-        weight_tversky = round(trial.suggest_float("weight_tversky", 0.1, 0.9), 3)
+        weight_tversky = _suggest_weight_tversky(weight_tversky)
         weight_focal = 1.0 - weight_tversky
         loss_function = losses.WeightedFocalTverskyLoss(
             gamma=gamma, alpha=alpha, beta=beta,
@@ -53,10 +90,13 @@ def get_loss_function(trial, loss_name = None):
         )
 
     elif loss_name == 'FocalTverskyLoss':
-        gamma = round(trial.suggest_float("gamma", 0.1, 2), 3)
-        alpha = round(trial.suggest_float("alpha", 0.1, 0.5), 3)
+        gamma = _suggest_gamma(gamma)
+        alpha = _suggest_alpha(alpha)
         beta = 1.0 - alpha
         loss_function = losses.FocalTverskyLoss(gamma=gamma, alpha=alpha, beta=beta)
+
+    else:
+        raise ValueError(f"Unsupported loss_function '{loss_name}'.")
 
     return loss_function
 

--- a/octopi/pytorch/submit_search.py
+++ b/octopi/pytorch/submit_search.py
@@ -17,7 +17,7 @@ class ExploreSubmitter:
         self,
         copick_config: str,
         target_name: str, target_user_id: str, target_session_id: str,
-        tomo_algorithm: str, voxel_size: float,
+        tomo_uris,
         model_type: str, best_metric: str = 'avg_f1',
         num_epochs: int = 1000, num_trials: int = 100,
         data_split: str = 0.8, random_seed: int = 42,
@@ -35,8 +35,7 @@ class ExploreSubmitter:
             target_name (str): Name of the target for segmentation.
             target_user_id (str): Optional user ID for tracking.
             target_session_id (str): Optional session ID for tracking.
-            tomo_algorithm (str): Tomogram algorithm to use.
-            voxel_size (float): Voxel size for tomograms.
+            tomo_uris: Tomogram URI(s) ('alg@voxel_size') for multi-resolution training.
             model_type (str): Type of model to use.
             random_seed (int): Seed for reproducibility.
             num_epochs (int): Number of epochs per trial.
@@ -55,8 +54,7 @@ class ExploreSubmitter:
         self.target_name = target_name
         self.target_user_id = target_user_id
         self.target_session_id = target_session_id
-        self.tomo_algorithm = tomo_algorithm
-        self.voxel_size = voxel_size
+        self.tomo_uris = tomo_uris
         self.model_type = model_type
         self.random_seed = random_seed
         self.num_epochs = num_epochs
@@ -222,7 +220,7 @@ class ExploreSubmitter:
         return dict(
             config=self.copick_config,
             name=self.target_name,user_id=self.target_user_id, session_id=self.target_session_id,
-            tomo_algorithm=self.tomo_algorithm, voxel_size=self.voxel_size,
+            tomo_uris=self.tomo_uris,
             model_type=self.model_type, best_metric=self.best_metric, num_epochs=self.num_epochs,
             num_trials=self.num_trials, background_ratio=self.background_ratio,
             data_split=self.data_split, random_seed=self.random_seed,
@@ -239,8 +237,8 @@ class ExploreSubmitter:
         target_info = [self.target_name, self.target_user_id, self.target_session_id]
         output_params = {
             'input': {
-                'config': self.copick_config, 'target_info': target_info, 
-                'tomo_algorithm': self.tomo_algorithm, 'voxel_size': self.voxel_size },
+                'config': self.copick_config, 'target_info': target_info,
+                'tomo_uris': self.tomo_uris },
             'optimization': {
                 'model_type': self.model_type, 'random_seed': self.random_seed, 
                 'num_trials': self.num_trials, 'best_metric': self.best_metric },

--- a/octopi/pytorch/trainer.py
+++ b/octopi/pytorch/trainer.py
@@ -3,6 +3,7 @@ from monai.inferers import sliding_window_inference
 from octopi.pytorch.train_helper import auto_amp
 from octopi.utils import stopping_criteria
 import torch, os, mlflow, re, optuna, time
+from contextlib import nullcontext
 from monai.transforms import AsDiscrete
 from monai.data import decollate_batch
 import torch_ema as ema
@@ -111,34 +112,54 @@ class ModelTrainer:
     @torch.no_grad()
     def validate_update(self):
         """
-        Validate patch-by-patch. GridPatchDataset yields individual patches so
-        the DataLoader batches them directly — no manual sub-batching needed.
+        Validate with full-volume sliding-window inference so the metric matches
+        inference-time behavior (overlap + Gaussian blending). Scoring independent,
+        zero-padded patches instead systematically underestimates F1 by splitting
+        particles at patch boundaries and losing edge context.
+
+        Memory: patch compute runs on self.device, but only sw_batch_size ROI
+        windows are resident there at once — the full volume never lands on the
+        GPU. The blended output is assembled on the CPU in the autocast dtype
+        (bf16/fp16), so the host buffer is a single 2-byte (Nclass, D, H, W)
+        volume, then upcast to fp32 only for the loss/metric math.
         """
         self.model.eval()
         val_loss = 0
         n_batches = 0
 
+        out_device = torch.device("cpu")
+        amp_ctx = (
+            torch.amp.autocast(device_type=self.device.type, dtype=self.amp_dtype)
+            if self.amp_enabled else nullcontext()
+        )
+
         for val_data in self.val_loader:
-            batch_in  = val_data["image"].to(self.device, non_blocking=True)
-            batch_lbl = val_data["label"].to(self.device, non_blocking=True)
+            # Keep the full volume on CPU; sliding_window_inference ships only
+            # ROI windows to sw_device, bounding GPU memory by sw_batch_size.
+            batch_in  = val_data["image"]
+            batch_lbl = val_data["label"]
 
-            with torch.amp.autocast(
-                device_type=self.device.type,
-                dtype=self.amp_dtype,
-                enabled=self.amp_enabled,
-            ):
-                batch_out = self.model(batch_in)
+            # Validation window with a 128³ floor (grows with crop_size if larger).
+            # A 3D U-Net is fully convolutional, so it accepts a window larger
+            # than the crop it trained on; 128 is divisible by 32 (safe for
+            # SwinUNETR).
+            roi = max(128, self.crop_size)
+            with amp_ctx:
+                batch_out = sliding_window_inference(
+                    inputs=batch_in,
+                    roi_size=(roi, roi, roi),
+                    sw_batch_size=self.sw_bs,
+                    predictor=self.model,
+                    overlap=self.overlap,
+                    mode="gaussian",
+                    sw_device=self.device,   # window compute
+                    device=out_device,       # output assembly (CPU)
+                )
 
-            # During eval, DS models already return a single tensor.
-            # Guard against any edge case where a list is returned.
-            if isinstance(batch_out, (list, tuple)):
-                batch_out = batch_out[0]
+            # Upcast the 2-byte assembly buffer to fp32 for stable loss/metric math.
+            batch_out = batch_out.float()
 
-            # Keep loss computation on GPU: the old path did a round-trip to
-            # CPU per batch (~2-4 GB transfer) and forced a GPU sync, which
-            # was the dominant cost of validation. .float() upcasts bf16/fp16
-            # output to fp32 for numeric stability in TverskyLoss.
-            loss = self.loss_function(batch_out.float(), batch_lbl)
+            loss = self.loss_function(batch_out, batch_lbl)
             val_loss += loss.item()
             n_batches += 1
 

--- a/octopi/utils/io.py
+++ b/octopi/utils/io.py
@@ -96,28 +96,32 @@ def get_optimizer_parameters(trainer):
     """
     Extract optimizer parameters from a trainer object.
     """
+    # Unwrap DeepSupervisionLoss so we record the BASE loss (e.g. FocalLoss + gamma) rather than
+    # the wrapper — the wrapper has no alpha/gamma and would otherwise drop those params on save.
+    base_loss = getattr(trainer.loss_function, 'loss', trainer.loss_function)
+
     optimizer_parameters = {
-        'my_num_samples': trainer.num_samples,  
+        'my_num_samples': trainer.num_samples,
         'val_interval': trainer.val_interval,
         'lr': trainer.lr0,
         'optimizer': trainer.optimizer.__class__.__name__,
         'metrics_function': trainer.metrics_function.__class__.__name__,
-        'loss_function': trainer.loss_function.__class__.__name__,
+        'loss_function': base_loss.__class__.__name__,
         'metric': trainer.best_metric
     }
 
-    # Log Tversky Loss Parameters
-    if trainer.loss_function.__class__.__name__ == 'TverskyLoss':
-        optimizer_parameters['alpha'] = trainer.loss_function.alpha
-    elif trainer.loss_function.__class__.__name__ == 'FocalLoss':
-        optimizer_parameters['gamma'] = trainer.loss_function.gamma
-    elif trainer.loss_function.__class__.__name__ == 'WeightedFocalTverskyLoss':
-        optimizer_parameters['alpha'] = trainer.loss_function.alpha
-        optimizer_parameters['gamma'] = trainer.loss_function.gamma
-        optimizer_parameters['weight_tversky'] = trainer.loss_function.weight_tversky
-    elif trainer.loss_function.__class__.__name__ == 'FocalTverskyLoss':
-        optimizer_parameters['alpha'] = trainer.loss_function.alpha
-        optimizer_parameters['gamma'] = trainer.loss_function.gamma
+    # Log Loss-specific Parameters
+    if base_loss.__class__.__name__ == 'TverskyLoss':
+        optimizer_parameters['alpha'] = base_loss.alpha
+    elif base_loss.__class__.__name__ == 'FocalLoss':
+        optimizer_parameters['gamma'] = base_loss.gamma
+    elif base_loss.__class__.__name__ == 'WeightedFocalTverskyLoss':
+        optimizer_parameters['alpha'] = base_loss.alpha
+        optimizer_parameters['gamma'] = base_loss.gamma
+        optimizer_parameters['weight_tversky'] = base_loss.weight_tversky
+    elif base_loss.__class__.__name__ == 'FocalTverskyLoss':
+        optimizer_parameters['alpha'] = base_loss.alpha
+        optimizer_parameters['gamma'] = base_loss.gamma
 
     # Include best trial information if available
     if trainer.best_trial:

--- a/octopi/utils/parsers.py
+++ b/octopi/utils/parsers.py
@@ -38,22 +38,42 @@ def string2bool(value: str):
 
 def parse_target(value: str) -> Tuple[str, Union[str, None], Union[str, None]]:
     """
-    Parse a single target string.
-    Expected formats:
+    Parse a target / segmentation query into (name, user_id, session_id).
+
+    Accepts the copick URI grammar (preferred):
       - "name"
+      - "name:user_id"
+      - "name:user_id/session_id"
+    and the legacy comma form for backward compatibility:
       - "name,user_id,session_id"
+
+    The voxel size is NOT part of this query (it is taken from --tomo-uri), so a
+    trailing '@voxel_size' is rejected.
     """
-    parts = value.split(',')
-    if len(parts) == 1:
-        obj_name = parts[0]
-        return obj_name, None, None
-    elif len(parts) == 3:
-        obj_name, user_id, session_id = parts
-        return obj_name, user_id, session_id
-    else:
+    # Legacy comma form (unambiguous: ':' / '/' never appear in the comma form).
+    if ',' in value:
+        parts = value.split(',')
+        if len(parts) == 1:
+            return parts[0], None, None
+        elif len(parts) == 3:
+            obj_name, user_id, session_id = parts
+            return obj_name, user_id, session_id
+        else:
+            raise argparse.ArgumentTypeError(
+                f"Invalid target format: '{value}'. Expected 'name' or 'name,user_id,session_id'."
+            )
+
+    # URI form: name[:user_id[/session_id]]
+    if '@' in value:
         raise argparse.ArgumentTypeError(
-            f"Invalid target format: '{value}'. Expected 'name' or 'name,user_id,session_id'."
+            f"Invalid query '{value}': do not include '@voxel_size' here; the voxel size "
+            f"is derived from --tomo-uri."
         )
+    name, sep, rest = value.partition(':')
+    if not sep:
+        return name, None, None
+    user_id, _, session_id = rest.partition('/')
+    return name, (user_id or None), (session_id or None)
 
 
 def parse_seg_target(value: str) -> List[Tuple[str, Union[str, None], Union[str, None]]]:


### PR DESCRIPTION
## Summary

This branch lands three related improvements to the training/inference pipeline:

1. **Multi-resolution training** — train a single model across multiple voxel spacings.
2. **Sliding-window validation** — validation metrics now match inference-time behavior.
3. **URI-based CLI** — unified `alg@voxel_size` / `name:user_id/session_id` query grammar across all commands.

---

## 1. Multi-resolution training

Models can now train on tomograms/targets at **multiple voxel spacings simultaneously**, making them robust across resolutions. Each `(algorithm, voxel_size)` pair is loaded at its native spacing with its matching target — no resampling.

- Tomograms are specified as repeatable URIs: `--tomo-uri wbp@10.0 --tomo-uri wbp@5.0`.
- The target segmentation's voxel size is **derived from each tomo URI** (no separate `--voxel-size`).
- A run/resolution is included only when **both** the tomogram and its target exist at that spacing (missing ones are skipped with a warning).
- Works for both single-config (`CopickDataModule`) and multi-config (`MultiCopickDataModule`) training, and flows through the Optuna architecture search.

**Prerequisite:** targets must be generated at each spacing via `create-targets` (the radius→voxel conversion already handles physical size per spacing).

## 2. Sliding-window validation

Validation previously scored independent, zero-padded patches via `GridPatchDataset`, which **systematically underestimated F1** by splitting particles at patch boundaries and losing edge context.

- Validation now runs **full-volume `sliding_window_inference`** (overlap + Gaussian blending), identical to inference.
- Memory stays bounded: window compute runs on GPU (`sw_batch_size`), while the output buffer is assembled on **CPU in the autocast dtype (bf16/fp16)** — fits 16–32 GB GPUs and only needs a single 2-byte volume buffer in host RAM.
- ROI is `max(128, crop_size)`, matching prior behavior.

## 3. URI-based CLI (breaking)

Unified all resource queries onto copick's native URI grammar for consistency:

| Command | Before | After |
|---|---|---|
| `train`, `model-explore` | `--voxel-size`, `--tomo-alg`, `--target-info name,user,session` | `--tomo-uri alg@vs` (repeatable), `--target-uri name:user/session` |
| `segment` | `--tomo-alg`, `--voxel-size`, `--seg-info` | `--tomo-uri alg@vs`, `--seg-uri name:user/session` |
| `localize` | `--seg-info` | `--seg-uri name:user/session` (keeps `--voxel-size`) |
| `membrane-extract` | `--seg-info`, `--picks-info` | `--seg-uri`, `--picks-uri` (keeps `--voxel-size`) |

- `parse_target` now understands the URI grammar (`name` / `name:user` / `name:user/session`) and still accepts the **legacy comma form** for backward compatibility.
- `localize`/`membrane-extract` keep `--voxel-size` as a separate flag — they have no `--tomo-uri` to derive it from, and membrane-extract runs two queries against one spacing.

### Bug fix

`segment` had both a leftover `--tomo-alg` (from `inference_parameters()`) and the new `--tomo-uri`. The stale flag passed a `tomo_alg` kwarg the rewritten `cli()` no longer accepted — **any real `octopi segment` run would have crashed** with an unexpected-keyword error (only `--help` worked, since `no_args_is_help` short-circuits). Removed the redundant flag.

---

## Breaking changes

- CLI flag renames above. Old scripts using `--voxel-size`/`--tomo-alg`/`--target-info`/`--seg-info`/`--picks-info` on the affected commands must migrate to the new URI flags. (The comma *value* form like `name,user,session` still parses, but the *flag names* changed.)
- `DataGeneratorConfig` and the data modules take `tomo_uris` instead of `voxel_size` + `tomo_algorithm`.

## Testing

- ✅ All touched files compile; full CLI smoke test — all 10 registered commands render `--help`.
- ✅ Unit-tested `parse_resolution_uris`, URI-aware `parse_target`, and `scan_runs` multi-resolution availability/ordering against mocks.
- ✅ Verified each command's click params exactly match its `cli()` signature (guards against the unexpected-keyword crash class).