### PR TITLE
fix: handle dict copick_config_path in score-weight lookup

### DIFF
--- a/octopi/entry_points/run_train.py
+++ b/octopi/entry_points/run_train.py
@@ -56,7 +56,14 @@ def train_model(
 
     # Read per-class score weights from copick config metadata (score_weight key)
     import copick as _copick
-    _config_path = copick_config_path if isinstance(copick_config_path, str) else copick_config_path[0]
+    if isinstance(copick_config_path, str):
+        _config_path = copick_config_path
+    elif isinstance(copick_config_path, dict):
+        # Multi-session training: parse_copick_configs returns {session_name: path}.
+        # Use the first config (score-weight metadata is shared across sessions).
+        _config_path = next(iter(copick_config_path.values()))
+    else:
+        _config_path = copick_config_path[0]
     _root = _copick.from_file(_config_path)
     class_weights = {
         obj.name: obj.metadata.get('weight', 1)


### PR DESCRIPTION
## Summary
`octopi train` crashes with `KeyError: 0` during multi-session training (when more than one `--config` is passed).

In `run_train.run_train`, the config paths are resolved as:
```python
if len(config) > 1:
    copick_configs = parsers.parse_copick_configs(config)  # dict {session_name: path}
else:
    copick_configs = config[0]                              # str
```
So `copick_config_path` is a **str** (single config) or a **dict** (multiple configs) — never a list. The per-class score-weight lookup in `train_model` then does:
```python
_config_path = copick_config_path if isinstance(copick_config_path, str) else copick_config_path[0]
```
For the dict case, `copick_config_path[0]` raises `KeyError: 0`, crashing before training starts.

## Fix
Resolve the config path by type explicitly:
- `str` -> use as-is
- `dict` -> use the first config value (`next(iter(...values()))`); score-weight metadata is shared across sessions
- otherwise (list/tuple) -> `[0]`, preserving prior behavior

## Test plan
- [x] Single `--config` (str): score weights load, training runs (unchanged behavior).
- [x] Multiple `--config` (dict): no longer raises `KeyError: 0`, training runs.