### PR TITLE
fix: add label override flag for localization

### DIFF
--- a/octopi/entry_points/run_localize.py
+++ b/octopi/entry_points/run_localize.py
@@ -128,7 +128,7 @@ def cli(config, method, seg_uri, voxel_size, runids,
 
 def run_localize(config, method, seg_info, voxel_size, runids,
         radius_min_scale, radius_max_scale, filter_size, pick_objects, n_procs,
-        pick_session_id, pick_user_id, seg_label = None):
+        pick_session_id, pick_user_id, seg_label: Optional[int] = None):
     """
     Run the localize command.
     """

--- a/octopi/entry_points/run_localize.py
+++ b/octopi/entry_points/run_localize.py
@@ -1,5 +1,5 @@
 from octopi.utils import parsers
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 import rich_click as click
 
 def pick_particles(
@@ -15,7 +15,7 @@ def pick_particles(
     pick_objects: List[str],
     runIDs: List[str],
     n_procs: int,
-    seg_label: int = None,
+    seg_label: Optional[int] = None,
     ):
     from octopi.workflows import localize
 

--- a/octopi/entry_points/run_localize.py
+++ b/octopi/entry_points/run_localize.py
@@ -15,14 +15,15 @@ def pick_particles(
     pick_objects: List[str],
     runIDs: List[str],
     n_procs: int,
+    seg_label: int = None,
     ):
     from octopi.workflows import localize
 
     # Run 3D Localization
     localize(
         copick_config_path, voxel_size, seg_info, pick_user_id, pick_session_id, n_procs,
-        method, filter_size, radius_min_scale, radius_max_scale, 
-        run_ids = runIDs, pick_objects = pick_objects
+        method, filter_size, radius_min_scale, radius_max_scale,
+        run_ids = runIDs, pick_objects = pick_objects, seg_label = seg_label
     )
 
 
@@ -83,6 +84,8 @@ def save_parameters(seg_info: Tuple[str, str, str],
               help="Specific Objects to Find Picks for")
 @click.option('-fs', '--filter-size', type=int, default=10,
               help="Filter size for localization")
+@click.option('-lbl', '--label', 'seg_label', type=int, default=None,
+              help="Segmentation label value to extract for all objects. Overrides the copick/model config labels.")
 @click.option('-rmax','--radius-max-scale', type=float, default=1.0,
               help="Maximum radius scale for particles")
 @click.option('-rmin', '--radius-min-scale', type=float, default=0.5,
@@ -102,7 +105,7 @@ def save_parameters(seg_info: Tuple[str, str, str],
 @click.option('-c', '--config', type=click.Path(exists=True), required=True,
               help="Path to the CoPick configuration file")
 def cli(config, method, seg_uri, voxel_size, runids,
-        radius_min_scale, radius_max_scale, filter_size, pick_objects, n_procs,
+        radius_min_scale, radius_max_scale, filter_size, seg_label, pick_objects, n_procs,
         pick_session_id, pick_user_id):
     """
     Convert Segmentation Masks to 3D Particle Coordinates.
@@ -120,12 +123,12 @@ def cli(config, method, seg_uri, voxel_size, runids,
     print('\n🚀 Localizing Segmentation Masks into 3D Coordinates...\n')
     run_localize(config, method, seg_uri, voxel_size, runids,
         radius_min_scale, radius_max_scale, filter_size, pick_objects, n_procs,
-        pick_session_id, pick_user_id)
-    
+        pick_session_id, pick_user_id, seg_label)
+
 
 def run_localize(config, method, seg_info, voxel_size, runids,
         radius_min_scale, radius_max_scale, filter_size, pick_objects, n_procs,
-        pick_session_id, pick_user_id):
+        pick_session_id, pick_user_id, seg_label = None):
     """
     Run the localize command.
     """
@@ -169,6 +172,7 @@ def run_localize(config, method, seg_info, voxel_size, runids,
         runIDs=runids,
         pick_objects=pick_objects,
         n_procs=n_procs,
+        seg_label=seg_label,
     )
 
 

--- a/octopi/workflows.py
+++ b/octopi/workflows.py
@@ -150,7 +150,7 @@ def segment(config, tomo_algorithm, voxel_size, model_weights, model_config,
 
 def localize(config, voxel_size, seg_info, pick_user_id, pick_session_id, n_procs = 16,
             method = 'watershed', filter_size = 10, radius_min_scale = 0.4, radius_max_scale = 1.0,
-            run_ids = None, pick_objects = None):
+            run_ids = None, pick_objects = None, seg_label = None):
     """
     Extract 3D Coordinates from the Segmentation Maps
 
@@ -166,6 +166,8 @@ def localize(config, voxel_size, seg_info, pick_user_id, pick_session_id, n_proc
         radius_min_scale (float): The minimum radius scale to use for localization
         radius_max_scale (float): The maximum radius scale to use for localization
         run_ids (list): The list of run IDs to use for localization
+        seg_label (int): Segmentation label value to extract for all objects. When set,
+            overrides the copick/model config labels (use for binary masks, foreground=1).
     """
     
     # Load the Copick Config
@@ -180,17 +182,21 @@ def localize(config, voxel_size, seg_info, pick_user_id, pick_session_id, n_proc
         if len(obj) < 3 or not isinstance(obj[2], (float, int)):
             raise ValueError(f"Invalid object format: {obj}. Expected a tuple with (name, label, radius).")
   
-    # Load the Model Output Configuration
-    seg_config = io.get_config(config, seg_info[0], 'segment', seg_info[1], seg_info[2])
+    if seg_label is not None:
+        for row in objects:
+            row[1] = int(seg_label)
+    else:
+        # Load the Model Output Configuration
+        seg_config = io.get_config(config, seg_info[0], 'segment', seg_info[1], seg_info[2])
 
-    # sync labels from the model config and remove objects not in model labels
-    label_map = seg_config.get('labels', {})
-    for row in objects.copy():  # avoid modifying the list while iterating
-        name, label, radius = row
-        if name in label_map and label != label_map[name]:
-            row[1] = int(label_map[name])  # mutate in place
-        elif name not in label_map: # remove this entry from objects 
-            objects.remove(row)
+        # sync labels from the model config and remove objects not in model labels
+        label_map = seg_config.get('labels', {})
+        for row in objects.copy():  # avoid modifying the list while iterating
+            name, label, radius = row
+            if name in label_map and label != label_map[name]:
+                row[1] = int(label_map[name])  # mutate in place
+            elif name not in label_map: # remove this entry from objects
+                objects.remove(row)
 
     # Filter objects based on the provided list
     if pick_objects is not None:


### PR DESCRIPTION
octopi localization fails when the copick config has a label that doesn't match the actual data. 

As per the copick docs, a label is the `numeric label/id for the object, as used in multilabel segmentation masks. Must be unique.`

In the case where a user wants to use octopi localization on a copick binary segmentation, this will fail when the object label is not 1 (for example, a ribosome binary segmentation where the ribosome object in copick has a label of 5).

This PR fixes this by providing the ability to add a manual override to specify the label octopi should be looking for, overriding the copick config value. 