### PR TITLE
fix: center of mass localization

### DIFF
--- a/octopi/extract/localize.py
+++ b/octopi/extract/localize.py
@@ -6,7 +6,6 @@ from scipy.spatial import cKDTree
 from typing import List, Optional, Tuple
 from copick_utils.io import readers
 import scipy.ndimage as ndi
-from tqdm import tqdm
 import numpy as np
 
 FOUR_THIRDS_PI = 4.0/3.0 * np.pi  # reuse
@@ -249,16 +248,15 @@ def extract_particle_centroids_via_com(
     object_sizes = np.bincount(label_objs.flat)
 
     # Filter the objects based on size
-valid_objects = np.where((object_sizes > min_particle_size) & (object_sizes < max_particle_size))[0]
-valid_objects = valid_objects[valid_objects != 0]
+    valid_objects = np.where((object_sizes > min_particle_size) & (object_sizes < max_particle_size))[0]
+    valid_objects = valid_objects[valid_objects != 0]
 
     # Estimate Coordinates from CoM for LabelMaps.
-    octopiCoords = []
-    for object_num in tqdm(valid_objects):
-        com = ndi.center_of_mass(label_objs == object_num)
-        octopiCoords.append(com)
-
-    return octopiCoords
+    return ndi.center_of_mass(
+        np.ones_like(label_objs, dtype=np.float32),
+        labels=label_objs,
+        index=valid_objects,
+    )
 
 def remove_repeated_picks(coordinates: np.ndarray,
                                distance_threshold: float) -> np.ndarray:

--- a/octopi/extract/localize.py
+++ b/octopi/extract/localize.py
@@ -251,12 +251,11 @@ def extract_particle_centroids_via_com(
     # Filter the objects based on size
     valid_objects = np.where((object_sizes > min_particle_size) & (object_sizes < max_particle_size))[0]
 
-    # Estimate Coordiantes from CoM for LabelMaps
+    # Estimate Coordinates from CoM for LabelMaps.
     octopiCoords = []
     for object_num in tqdm(valid_objects):
         com = ndi.center_of_mass(label_objs == object_num)
-        swapped_com = (com[2], com[1], com[0])
-        octopiCoords.append(swapped_com)
+        octopiCoords.append(com)
 
     return octopiCoords
 

--- a/octopi/extract/localize.py
+++ b/octopi/extract/localize.py
@@ -249,7 +249,8 @@ def extract_particle_centroids_via_com(
     object_sizes = np.bincount(label_objs.flat)
 
     # Filter the objects based on size
-    valid_objects = np.where((object_sizes > min_particle_size) & (object_sizes < max_particle_size))[0]
+valid_objects = np.where((object_sizes > min_particle_size) & (object_sizes < max_particle_size))[0]
+valid_objects = valid_objects[valid_objects != 0]
 
     # Estimate Coordinates from CoM for LabelMaps.
     octopiCoords = []


### PR DESCRIPTION
Return centroids in (Z,Y,X) order to match the watershed path; the single (Z,Y,X)->(X,Y,Z) swap in process_localization is the only coordinate flip.

Copilot also introduces a performance speed up by running com localization on all objects instead of looping through and doing it object by object.